### PR TITLE
feat(release): mark beta one ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.1] - 2026-08-28
+
 ### Added
 
 - Canonical OMP NInfer product repository and naming.
-- Draft `v0.1.0-beta.1` manifest binding OMP, NInfer, Qwen3.8, the RTX 5090 profile,
-  qualification evidence, Homebrew, and publication blockers.
-- Invited-tester quickstart for OMP on Apple-silicon macOS connected through an authenticated SSH
-  local forward to NInfer on a Linux or WSL2 RTX 5090 host.
+- Ready `v0.1.0-beta.1` manifest binding the native Windows OMP component, NInfer, Qwen3.8,
+  the RTX 5090 profile, qualification summary, compatibility authority, and acceptance receipt.
+- Ready native Windows quickstart plus managed macOS SSH and native Linux preview routes.
 - Digest- and hash-verifying NInfer launcher, owned-container stop path, OMP provider fragment, and
   fail-closed OMP overlay.
 - Runtime qualification summary covering exact long context, serving protocols, Vision, stateful
@@ -33,16 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reviewed draft OMP transport for read-only remote `doctor`/`status`, with mutating operations and
   later lifecycle ownership still fail-closed.
 - Published and bound the exact OMP, Homebrew, NInfer OCI, binary-package, SPDX, and checksum
-  identities; advanced the product manifest to an installable candidate while external acceptance
-  and ready publication remain open.
+  identities; advanced the product manifest through installable candidate to externally accepted
+  ready release.
+- Owner-operated tester-equivalent Windows clean install from public URLs, including tools, Vision,
+  stateful exit/resume, fail-closed outage behavior, and exact runtime restoration.
 
 ### Security
 
 - Restricted both NInfer and tunnel listeners to loopback in the supported profile.
 - Required a user-only NInfer bearer-key file and disabled OMP model fallback for beta acceptance.
-- Required immutable model, binary, image, SBOM, OMP artifact, qualification-summary, and Homebrew
+- Required immutable model, binary, image, SBOM, OMP artifact, qualification-summary, and component
   identities before a release can move from `draft` to `ready`.
 - Excluded secrets, private host identifiers, prompts, model output, and raw logs from support
   material.
 
-[Unreleased]: https://github.com/alphastorm/omp-ninfer/commits/main
+[Unreleased]: https://github.com/alphastorm/omp-ninfer/compare/v0.1.0-beta.1...HEAD
+[0.1.0-beta.1]: https://github.com/alphastorm/omp-ninfer/releases/tag/v0.1.0-beta.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Private Qwen coding appliance for RTX 5090**
 
 Run a stateful Qwen3.8 coding model on your own NVIDIA GPU and use it from
-[Oh My Pi](https://github.com/can1357/oh-my-pi) on a Mac.
+[Oh My Pi](https://github.com/can1357/oh-my-pi) on native Windows, Linux, or a Mac.
 
 **[Early-access setup](docs/QUICKSTART.md)** · **[Release status](docs/RELEASES.md)** ·
 **[Architecture](docs/ARCHITECTURE.md)** · **[Security](docs/SECURITY.md)** ·
@@ -16,10 +16,10 @@ Run a stateful Qwen3.8 coding model on your own NVIDIA GPU and use it from
 </div>
 
 > [!IMPORTANT]
-> The tracked `v0.1.0-beta.1` manifest is an installable **candidate**, not a ready product release.
-> The immutable OMP artifact, NInfer image, SBOM, and Homebrew beta cask are public and bound; the
-> clean external-install acceptance and final qualification publication remain open. Do not
-> advertise an install command or substitute an unpinned image or older local package.
+> The tracked `v0.1.0-beta.1` manifest is a technically **ready** invited-tester release.
+> The primary accepted route is native Windows OMP with Docker Desktop WSL2 on one RTX 5090; the
+> published macOS and Linux clients remain preview profiles. Every component is immutable and bound.
+> Use only the tagged quickstart and checksums; this is not a general-availability support claim.
 
 OMP NInfer is the product and release layer joining OMP, NInfer, and one qualified Qwen3.8 artifact.
 It owns the supported topology, versioned profile, release manifest, installation path, qualification
@@ -33,6 +33,8 @@ without turning an early package into a broad support claim. The versioned
 [`compatibility.json`](compatibility.json) is the platform/profile authority; the public
 [`compatibility matrix`](docs/COMPATIBILITY.md) is generated from it. `preview` and `blocked` rows
 are not support claims, even when they reference the shared qualified RTX 5090 runtime.
+The ready primary profile is `qwen38-rtx5090-windows-docker-local`; it passed a clean public-asset
+install, tools, Vision, stateful resume, fail-closed outage behavior, and exact runtime restoration.
 
 The runtime qualification recorded an exact 130,048-token retrieval, OpenAI/Anthropic/Responses
 protocol behavior, image input, stateful continuation and forks, cache reuse, an exact Golden task,
@@ -46,9 +48,8 @@ identity without re-running the benchmark. See
 
 The first beta does **not** claim automated remote appliance installation, managed upgrade or
 rollback, process-restart continuation, RTX 4090 support, multi-GPU scheduling, or broad hardware
-compatibility. OMP's `omp appliance ...` source work remains the long-term command surface, but the
-first beta uses a manual tunnel and a custom provider while that remote lifecycle is finished and
-qualified. See [`ROADMAP.md`](ROADMAP.md).
+compatibility. Native Windows is the accepted local client/runtime topology; managed macOS SSH and
+native Linux remain preview profiles. See [`ROADMAP.md`](ROADMAP.md).
 
 ## Repository ownership
 
@@ -60,8 +61,8 @@ qualified. See [`ROADMAP.md`](ROADMAP.md).
   container, and numerical/runtime evidence.
 - [`alphastorm/ninfer-4090`](https://github.com/alphastorm/ninfer-4090): RTX 4090 runtime work,
   deferred from the first beta.
-- [`alphastorm/homebrew-omp`](https://github.com/alphastorm/homebrew-omp): stable and beta Homebrew
-  casks for the macOS OMP client.
+- [`alphastorm/homebrew-omp`](https://github.com/alphastorm/homebrew-omp): published native client
+  component archives plus stable and beta Homebrew casks.
 
 The user-facing command remains `omp`. “Appliance” names the install/operate concept and command
 surface; **OMP NInfer** names this integration and repository.
@@ -75,11 +76,10 @@ python3 scripts/verify_release.py --require-ready
 python3 -m unittest discover -s tests -v
 ```
 
-The first command still fails by design while the manifest is `candidate`. The candidate passes
-`--require-installable`, so maintainers can run the clean external-install gate from its exact
-commit, but no tester install command is advertised yet. It moves to `ready` only after that result
-and the final qualification publication are exact. Published product tags and release assets must
-use the same ready manifest bytes.
+Both commands pass on the tagged release. The ready manifest binds the accepted Windows archive,
+compatibility authority, NInfer image/SBOM, model, qualification summary, and owner-operated
+tester-equivalent acceptance receipt. Published product tags and release notes must use those exact
+bytes.
 
 ## Feedback
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -49,7 +49,7 @@ The version must be `omp/18.0.7`. The installer retains the previous client poin
 Inside WSL2, continue with **3. Prepare the model and key** and **4. Start NInfer** below. Skip
 the macOS tunnel/key-copy sections: Docker Desktop exposes the WSL2 loopback service to native
 Windows at `127.0.0.1:18089`. Then use the **Native Windows OMP** provider instructions in
-section 7 and run every acceptance check in section 8.
+section 7 and the **Native Windows command forms** at the start of section 8.
 
 ## Managed macOS SSH preview route
 
@@ -210,30 +210,31 @@ providers or model definitions. The key remains an executable secret reference:
 apiKey: '!cat "$HOME/.omp/agent/ninfer-beta.key"'
 ```
 
+For the macOS/Linux shell route, install the fail-closed default config:
+
+```sh
+install -m 600 examples/manual-tunnel/fail-closed.yml \
+  "$HOME/.omp/agent/config.yml"
+```
+
 ### Native Windows OMP
 
 The POSIX `!cat` secret reference is not supported by native Windows OMP. Copy
 [`examples/windows-docker-local/models.fragment.yml`](../examples/windows-docker-local/models.fragment.yml)
 to `$HOME\.omp\agent\models.yml`, or merge only its `providers.ninfer-beta` mapping.
-Load the key into the process environment without printing it before every OMP launch:
+Install the fail-closed default config and load the key without printing it before every OMP launch:
 
 ```powershell
+$Agent = Join-Path $HOME '.omp\agent'
+New-Item -ItemType Directory -Force -Path $Agent | Out-Null
+Copy-Item .\examples\windows-docker-local\models.fragment.yml (Join-Path $Agent 'models.yml')
+Copy-Item .\examples\manual-tunnel\fail-closed.yml (Join-Path $Agent 'config.yml')
 $env:NINFER_BETA_API_KEY = (Get-Content -Raw "$HOME\.omp\agent\ninfer-beta.key").Trim()
-omp --model ninfer-beta/local-max
+& "$env:LOCALAPPDATA\OMP\omp.cmd" --model ninfer-beta/local-max
 ```
 
 The environment-backed value exists only in that PowerShell process and its children. Do not put
 the key itself in YAML, command arguments, shell history, or support bundles.
-
-Install the supplied fail-closed settings into the launcher-owned default config whenever exercising
-the beta. If the file already exists, merge only the `retry` mapping instead of overwriting unrelated
-settings:
-
-```sh
-install -m 600 examples/manual-tunnel/fail-closed.yml \
-  "$HOME/.omp/agent/config.yml"
-omp --model ninfer-beta/local-max
-```
 
 The sealed launcher owns config selection and deliberately rejects `--config`; the default config plus
 the explicit provider/model disable model fallback. A tunnel or runtime failure must be an error, not a
@@ -243,6 +244,52 @@ switch to a cloud model.
 
 Run these checks in order and record only pass/fail plus the content-safe identities from the NInfer
 launcher.
+
+### Native Windows command forms
+
+Run from the tagged product clone in the same PowerShell process that loaded
+`NINFER_BETA_API_KEY`:
+
+```powershell
+$Launcher = "$env:LOCALAPPDATA\OMP\omp.cmd"
+$Smoke = Join-Path $env:TEMP ("omp-ninfer-acceptance-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $Smoke | Out-Null
+Set-Content -NoNewline -Encoding ascii -Path (Join-Path $Smoke 'marker.txt') -Value 'OMP_NINFER_TOOL_OK'
+Push-Location $Smoke
+try {
+  & $Launcher -p --no-session --auto-approve --model ninfer-beta/local-max `
+    'Use a file-reading tool to read marker.txt, then report its exact single line.'
+  if ($LASTEXITCODE -ne 0) { throw 'text/tool acceptance failed' }
+} finally { Pop-Location }
+
+$Image = (Resolve-Path .\assets\icon-512.png).Path
+& $Launcher -p --no-session --auto-approve --model ninfer-beta/local-max `
+  ("@" + $Image) 'Describe the visible image in one sentence.'
+if ($LASTEXITCODE -ne 0) { throw 'Vision acceptance failed' }
+
+$Session = Join-Path $Smoke 'sessions'
+& $Launcher -p --auto-approve --session-dir $Session --model ninfer-beta/local-max `
+  'Remember the nonce COBALT-493817 for my next turn. Acknowledge briefly.'
+if ($LASTEXITCODE -ne 0) { throw 'state setup failed' }
+& $Launcher -p --auto-approve --session-dir $Session --continue `
+  'Return only the nonce from the prior turn.'
+if ($LASTEXITCODE -ne 0) { throw 'stateful resume failed' }
+```
+
+For the fail-closed check, stop the owned runtime from the tagged WSL2 clone, then issue one
+native Windows request:
+
+```powershell
+wsl.exe -d Ubuntu-24.04 -- bash -lc 'cd ~/omp-ninfer && ./examples/manual-tunnel/stop-ninfer.sh'
+& $Launcher -p --no-session --auto-approve --max-time 20s `
+  --model ninfer-beta/local-max 'Return LOCAL_ONLY.'
+if ($LASTEXITCODE -eq 0) { throw 'outage request unexpectedly succeeded' }
+```
+
+Expected result: a connection/authentication failure and no model response. Any cloud-provider
+request is a release failure. Restart NInfer with section 4 only after observing the failure.
+
+### macOS/Linux command forms
 
 ### Text and tool turn
 
@@ -291,7 +338,7 @@ continuation.
 
 ### Fail closed
 
-Stop the tunnel with `Ctrl-C`, then run:
+For the managed macOS route, stop the tunnel with `Ctrl-C`, then run:
 
 ```sh
 omp --no-session --max-time 20s \

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -47,7 +47,7 @@ tar -xzf omp-18.0.7-windows-x64.tar.gz
 The version must be `omp/18.0.7`. The installer retains the previous client pointer when one exists.
 
 Inside WSL2, continue with **3. Prepare the model and key** and **4. Start NInfer** below. Skip
-the macOS tunnel/key-copy sections: Docker Desktop exposes the WSL2 loopback service to native
+the macOS tunnel sections: Docker Desktop exposes the WSL2 loopback service to native
 Windows at `127.0.0.1:18089`. Then use the **Native Windows OMP** provider instructions in
 section 7 and the **Native Windows command forms** at the start of section 8.
 
@@ -227,14 +227,29 @@ Install the fail-closed default config and load the key without printing it befo
 ```powershell
 $Agent = Join-Path $HOME '.omp\agent'
 New-Item -ItemType Directory -Force -Path $Agent | Out-Null
-Copy-Item .\examples\windows-docker-local\models.fragment.yml (Join-Path $Agent 'models.yml')
-Copy-Item .\examples\manual-tunnel\fail-closed.yml (Join-Path $Agent 'config.yml')
-$env:NINFER_BETA_API_KEY = (Get-Content -Raw "$HOME\.omp\agent\ninfer-beta.key").Trim()
+$KeyPath = Join-Path $Agent 'ninfer-beta.key'
+$KeyText = (& wsl.exe -d Ubuntu-24.04 -- bash -lc 'cat "$HOME/.config/omp-ninfer/api-key"' | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($KeyText)) { throw 'NInfer key copy from WSL2 failed' }
+[IO.File]::WriteAllText($KeyPath, $KeyText, [Text.UTF8Encoding]::new($false))
+$Identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+& icacls.exe $KeyPath /inheritance:r /grant:r "${Identity}:(R,W)" | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'NInfer key ACL restriction failed' }
+
+$ModelsPath = Join-Path $Agent 'models.yml'
+$ConfigPath = Join-Path $Agent 'config.yml'
+if ((Test-Path $ModelsPath) -or (Test-Path $ConfigPath)) {
+  throw 'Existing OMP models/config found; merge providers.ninfer-beta and retry mappings instead of overwriting them.'
+}
+Copy-Item .\examples\windows-docker-local\models.fragment.yml $ModelsPath
+Copy-Item .\examples\manual-tunnel\fail-closed.yml $ConfigPath
+$env:NINFER_BETA_API_KEY = (Get-Content -Raw $KeyPath).Trim()
 & "$env:LOCALAPPDATA\OMP\omp.cmd" --model ninfer-beta/local-max
 ```
 
 The environment-backed value exists only in that PowerShell process and its children. Do not put
-the key itself in YAML, command arguments, shell history, or support bundles.
+the key itself in YAML, command arguments, shell history, or support bundles. The block refuses to
+overwrite an existing OMP configuration; merge only `providers.ninfer-beta` and the `retry` mapping
+when those files already exist.
 
 The sealed launcher owns config selection and deliberately rejects `--config`; the default config plus
 the explicit provider/model disable model fallback. A tunnel or runtime failure must be an error, not a

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,23 +1,57 @@
 # Early-access quickstart
 
-This is the supported `v0.1.0-beta.1` path: OMP on Apple-silicon macOS, NInfer on one
-user-controlled Linux or WSL2 RTX 5090 host, and an authenticated SSH local forward between them.
-It is deliberately manual. Do not use `omp appliance install` for this beta.
+The ready `v0.1.0-beta.1` route is native Windows OMP connected over authenticated local loopback
+to the exact NInfer container in Docker Desktop WSL2 on one user-controlled RTX 5090. Managed
+macOS SSH and native Linux clients are published preview profiles, not additional ready claims.
 
-The checked-in manifest is currently an installable `candidate`. Invited testers must still stop
-unless the product release tag exists and the ready contract succeeds from a clean clone of that
-tag. Maintainers may use the exact candidate commit for the bounded external-install acceptance:
+Start only from the product tag and require its ready contract:
 
 ```sh
 python3 scripts/verify_release.py --require-ready
 ```
 
-That gate prevents these instructions from resolving an unpinned image or unfinished OMP package.
-The only pre-tag exception is the bounded maintainer acceptance gate: it uses an exact public
-`candidate` commit after every installable artifact is pinned, and must first pass
-`python3 scripts/verify_release.py --require-installable`. A candidate is not an invited-tester
-release and cannot be tagged until this quickstart succeeds and the observed result is bound into a
-`ready` manifest.
+That gate binds the Windows client archive and binary, compatibility authority, NInfer image/SBOM,
+model, configuration, qualification summary, and clean-install acceptance receipt.
+
+## Ready route: native Windows and Docker Desktop WSL2
+
+### Prerequisites
+
+- Windows 11 x64 and a single NVIDIA GeForce RTX 5090;
+- Docker Desktop using Linux containers, WSL2 Ubuntu 24.04, and the NVIDIA container runtime;
+- Git, PowerShell, and at least 40 GiB free for the model, image, client, and logs; and
+- one trusted owner for Windows and the WSL2 runtime.
+
+### Clone and verify the exact product release
+
+Clone the tag in Windows and in the WSL2 namespace that owns Docker:
+
+```powershell
+git clone --branch v0.1.0-beta.1 --depth 1 https://github.com/alphastorm/omp-ninfer.git
+Set-Location omp-ninfer
+python3 scripts/verify_release.py --require-ready
+```
+
+### Install the exact native Windows client
+
+```powershell
+$Url = 'https://github.com/alphastorm/homebrew-omp/releases/download/omp-18.0.7-cross-platform-preview-5/omp-18.0.7-windows-x64.tar.gz'
+$Expected = '4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7'
+Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile omp-18.0.7-windows-x64.tar.gz
+if ((Get-FileHash omp-18.0.7-windows-x64.tar.gz -Algorithm SHA256).Hash.ToLowerInvariant() -cne $Expected) { throw 'OMP archive checksum mismatch' }
+tar -xzf omp-18.0.7-windows-x64.tar.gz
+& .\omp-18.0.7-windows-x64\install.ps1
+& "$env:LOCALAPPDATA\OMP\omp.cmd" --version
+```
+
+The version must be `omp/18.0.7`. The installer retains the previous client pointer when one exists.
+
+Inside WSL2, continue with **3. Prepare the model and key** and **4. Start NInfer** below. Skip
+the macOS tunnel/key-copy sections: Docker Desktop exposes the WSL2 loopback service to native
+Windows at `127.0.0.1:18089`. Then use the **Native Windows OMP** provider instructions in
+section 7 and run every acceptance check in section 8.
+
+## Managed macOS SSH preview route
 
 ## Prerequisites
 
@@ -51,37 +85,24 @@ python3 scripts/verify_release.py --require-ready
 
 Do not invite testers from moving `main`, an untagged archive, or a manifest whose status is
 `draft` or `candidate`.
-The bounded pre-tag acceptance instead checks out its recorded candidate commit in detached mode;
-it must never use moving `main` as the tested identity.
 
 ## 2. Install the OMP beta on the Mac
 
 ```sh
 (
 set -euo pipefail
-brew tap alphastorm/omp
-brew update
-CASK_REVISION=$(python3 -c \
-  'import json; print(json.load(open("releases/v0.1.0-beta.1/manifest.json"))["components"]["omp"]["homebrew_cask_revision"])')
-TAP_ROOT=$(brew --repository alphastorm/omp)
-git -C "$TAP_ROOT" fetch --quiet origin "$CASK_REVISION"
-PINNED_CASK_SHA=$(git -C "$TAP_ROOT" show "$CASK_REVISION:Casks/omp-beta.rb" | shasum -a 256 | cut -d ' ' -f 1)
-CURRENT_CASK_SHA=$(shasum -a 256 "$TAP_ROOT/Casks/omp-beta.rb" | cut -d ' ' -f 1)
-test "$CURRENT_CASK_SHA" = "$PINNED_CASK_SHA"
-
-if brew list --cask omp >/dev/null 2>&1; then
-  brew uninstall --cask omp
-fi
-HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask omp-beta
-omp --version
+URL='https://github.com/alphastorm/homebrew-omp/releases/download/omp-18.0.7-cross-platform-preview-5/omp-18.0.7-macos-arm64.tar.gz'
+EXPECTED='f619ce2266f07ebe5c16a75dfe9d84381562c13c2c6bee0a1d1e56f040222ec9'
+curl --fail --location --output omp-18.0.7-macos-arm64.tar.gz "$URL"
+test "$(shasum -a 256 omp-18.0.7-macos-arm64.tar.gz | cut -d ' ' -f 1)" = "$EXPECTED"
+tar -xzf omp-18.0.7-macos-arm64.tar.gz
+./omp-18.0.7-macos-arm64/install.sh
+"${XDG_BIN_HOME:-$HOME/.local/bin}/omp" --version
 )
 ```
 
-The stable and beta casks deliberately conflict because both own the same immutable release root and
-`~/.local/bin/omp` launcher. The content comparison prevents a moving tap from substituting a
-different beta cask after the manifest was cut; `HOMEBREW_NO_AUTO_UPDATE` keeps it fixed through
-installation. Do not manually overwrite the stable binary. To return to stable, uninstall
-`omp-beta` and reinstall `omp`.
+The version must be `omp/18.0.7`. This native preview package uses the same current/previous client
+pointer contract as Windows and Linux; it does not change the stable Homebrew cask.
 
 ## 3. Prepare the model and key on the inference host
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -7,7 +7,7 @@ the product manifest binds the exact combination.
 
 | Channel | Meaning | Current state |
 | --- | --- | --- |
-| Early access | Invited testers, narrow exact profile, known manual steps and non-claims | `v0.1.0-beta.1` draft |
+| Early access | Invited testers, narrow exact profile, known manual steps and non-claims | `v0.1.0-beta.1` ready prerelease |
 | Stable | Broadly advertised supported release | none |
 | Development | Branch content with no install/support claim | `main` after publication |
 
@@ -18,7 +18,7 @@ unchanged; early access uses `omp-beta`.
 
 - Product prerelease: `alphastorm/omp-ninfer@v0.1.0-beta.1`
 - RTX 5090 runtime component: `alphastorm/ninfer@v0.1.0-qwen38-5090`
-- macOS package channel: `alphastorm/omp/omp-beta`
+- native client component: `alphastorm/homebrew-omp@omp-18.0.7-cross-platform-preview-5`
 - RTX 4090 runtime: no v0.1 product binding
 
 A component tag does not make the product release ready. The product tag must carry the exact ready
@@ -65,7 +65,7 @@ Authorization for those external effects remains separate and bounded.
 
 Before the final external-install smoke, freeze these bytes together:
 
-1. OMP macOS archive;
+1. OMP Windows x64 archive and binary;
 2. NInfer OCI manifest and every referenced platform blob;
 3. NInfer SBOM;
 4. Qwen artifact revision;
@@ -80,15 +80,15 @@ mutable tag or rebinding an old qualification to new bytes is prohibited.
 
 ## External-install acceptance
 
-The final gate starts from a tester-equivalent Mac and RTX 5090 host with no developer-local paths or
-unpublished assets. It follows [`QUICKSTART.md`](QUICKSTART.md) from the exact `candidate` commit
-whose installable contract passes; the final product tag is created only after the observed result
-is bound into the `ready` manifest and qualification summary. The gate proves:
+The final gate used a clean isolated native Windows client root and the exact Docker Desktop WSL2
+RTX 5090 runtime identity. It downloaded the public client and compatibility authority, then bound
+the result into the `ready` manifest and qualification summary before the product tag. The gate
+proved:
 
-- Homebrew beta installation and exact OMP version;
-- model download byte count and hash;
-- digest-pinned NInfer pull, binary hash, and authenticated identity;
-- remote-loopback SSH tunnel;
+- published Windows archive and installed binary checksums plus exact OMP version;
+- exact served model artifact hash;
+- digest-pinned NInfer image, binary hash, and authenticated identity;
+- Windows local-loopback connectivity to Docker Desktop WSL2;
 - explicit fail-closed OMP provider resolution;
 - text/tool, image, stateful follow-up, and OMP exit/resume;
 - disconnected-tunnel failure with no cloud answer; and

--- a/profiles/qwen38-rtx5090-windows-docker-local.json
+++ b/profiles/qwen38-rtx5090-windows-docker-local.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": 1,
+  "profile_id": "qwen38-rtx5090-windows-docker-local",
+  "release": "v0.1.0-beta.1",
+  "status": "early-access",
+  "installation_mode": "native-windows-docker-local",
+  "client": {
+    "os": "Windows 11",
+    "architecture": "x64",
+    "component_release_tag": "omp-18.0.7-cross-platform-preview-5",
+    "asset_url": "https://github.com/alphastorm/homebrew-omp/releases/download/omp-18.0.7-cross-platform-preview-5/omp-18.0.7-windows-x64.tar.gz",
+    "asset_sha256": "4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7",
+    "binary_sha256": "0b59681010427a77aa39f7929576e270e91f8e8cc563a9f32f865090fc9ec892"
+  },
+  "runtime_host": {
+    "os": [
+      "Windows 11",
+      "WSL2 Ubuntu 24.04"
+    ],
+    "ownership": "single-trusted-user",
+    "gpu": "NVIDIA GeForce RTX 5090",
+    "cuda_architecture": "sm_120a",
+    "minimum_vram_mib": 32607,
+    "container_runtime": "Docker Desktop Linux containers with NVIDIA runtime"
+  },
+  "transport": {
+    "kind": "windows-local-loopback",
+    "client_bind_host": "127.0.0.1",
+    "client_port": 18089,
+    "runtime_bind_host": "127.0.0.1",
+    "runtime_port": 18089,
+    "authentication": "NInfer bearer token loaded from a user-only file into NINFER_BETA_API_KEY",
+    "silent_cloud_fallback": false
+  },
+  "model": {
+    "public_id": "q38-ninfer",
+    "artifact_sha256": "eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e",
+    "artifact_bytes": 18210531328
+  },
+  "server": {
+    "executable": "/usr/local/bin/ninfer-serve",
+    "deployment_profile": "qwen38-5090-v0.1.0",
+    "container_network_mode": "host",
+    "restart_policy": "no",
+    "arguments": [
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "18089",
+      "--model-id",
+      "q38-ninfer",
+      "--binary-sha256",
+      "af557e9b146c68b051bd29e9e7a7d172e908f4b12df4e6d3bd83c54ce58b2399",
+      "--artifact-sha256",
+      "eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e",
+      "--config-sha256",
+      "c6b635ccab19fd712ba503cd051b5359bb9c355068706b17372860baa0de49b6",
+      "--deployment-profile",
+      "qwen38-5090-v0.1.0",
+      "--max-context",
+      "131072",
+      "--kv-capacity",
+      "auto",
+      "--prefill-chunk",
+      "1024",
+      "--kv-dtype",
+      "bf16",
+      "--max-concurrency",
+      "1",
+      "--spec",
+      "mtp",
+      "--draft-tokens",
+      "3",
+      "--lm-head-draft",
+      "--vision",
+      "--preserve-thinking"
+    ]
+  },
+  "omp_provider": {
+    "id": "ninfer-beta",
+    "model_alias": "local-max",
+    "request_model_id": "q38-ninfer",
+    "base_url": "http://127.0.0.1:18089/v1",
+    "api": "openai-responses",
+    "reasoning": true,
+    "input": [
+      "text",
+      "image"
+    ],
+    "supports_tools": true,
+    "context_window": 131072,
+    "maximum_output_tokens": 32768,
+    "ninfer_stateful_responses": true,
+    "cost": {
+      "input": 0,
+      "output": 0,
+      "cacheRead": 0,
+      "cacheWrite": 0
+    }
+  },
+  "capabilities": [
+    "text",
+    "reasoning",
+    "tools",
+    "vision",
+    "stateful-responses",
+    "prefix-reuse"
+  ],
+  "unsupported": [
+    "native-windows-ninfer",
+    "native-windows-cuda",
+    "automatic-container-restart",
+    "process-restart-continuation",
+    "rtx4090",
+    "multi-gpu",
+    "multi-tenant"
+  ]
+}

--- a/releases/v0.1.0-beta.1/acceptance/windows-owner-clean-install.json
+++ b/releases/v0.1.0-beta.1/acceptance/windows-owner-clean-install.json
@@ -1,0 +1,71 @@
+{
+  "artifact_type": "omp_ninfer_external_install_acceptance",
+  "schema_version": 1,
+  "release": "v0.1.0-beta.1",
+  "status": "passed",
+  "observed_at": "2026-08-28",
+  "operator_class": "owner-operated tester-equivalent",
+  "topology": "native Windows OMP with Docker Desktop WSL2 RTX 5090 NInfer",
+  "public_inputs_only": true,
+  "product_source": {
+    "repository": "https://github.com/alphastorm/omp-ninfer",
+    "candidate_main_commit": "b9e9d7675ae320a81922bf88143541dac3f42eca",
+    "compatibility_authority": "omp-ninfer-v0.1.0-beta.1-cross-platform-preview-9",
+    "compatibility_sha256": "225619d324c9e722002a4b7b48f3059f444460c5d981b16525e859414a8ea7bc"
+  },
+  "omp_client": {
+    "release_tag": "omp-18.0.7-cross-platform-preview-5",
+    "release_id": 378212363,
+    "asset_id": 533095343,
+    "asset_url": "https://github.com/alphastorm/homebrew-omp/releases/download/omp-18.0.7-cross-platform-preview-5/omp-18.0.7-windows-x64.tar.gz",
+    "asset_bytes": 78452185,
+    "asset_sha256": "4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7",
+    "binary_sha256": "0b59681010427a77aa39f7929576e270e91f8e8cc563a9f32f865090fc9ec892",
+    "version_output": "omp/18.0.7",
+    "clean_install": true,
+    "previous_retained": false
+  },
+  "runtime": {
+    "image_digest": "sha256:a19e00c5d7993d7c12341974bdc7e3d13e61d9deaf39e8ce00cf94abd6137712",
+    "server_binary_sha256": "af557e9b146c68b051bd29e9e7a7d172e908f4b12df4e6d3bd83c54ce58b2399",
+    "model_sha256": "eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e",
+    "configuration_sha256": "c6b635ccab19fd712ba503cd051b5359bb9c355068706b17372860baa0de49b6"
+  },
+  "checks": {
+    "public_archive_download": "passed",
+    "archive_checksum": "passed",
+    "clean_native_install": "passed",
+    "installed_binary_checksum": "passed",
+    "version": "passed",
+    "compatibility_authority_checksum": "passed",
+    "windows_docker_gpu_doctor": "passed-with-preview-blockers",
+    "appliance_status": "passed",
+    "authenticated_text_and_file_tool": "passed",
+    "vision": "passed",
+    "stateful_exit_and_resume": "passed",
+    "runtime_outage_fail_closed": "passed",
+    "cloud_fallback_absent": "passed",
+    "runtime_incumbent_restore": "passed"
+  },
+  "doctor": {
+    "receipt_id": "a2639218-2f89-4283-a230-7f7da0ab54cc",
+    "status": "blocked",
+    "support_status": "preview"
+  },
+  "safety": {
+    "cloud_fallback_observed": false,
+    "production_omp_activation_performed": false,
+    "product_tag_created": false,
+    "runtime_incumbent_restored": true
+  },
+  "disposition": {
+    "external_installation_qualified": true,
+    "product_ready_gate_satisfied": true,
+    "future_tester_defects": "Fix in the next release unless a release-integrity or safety issue requires withdrawal."
+  },
+  "limitations": [
+    "This acceptance was owner-operated on a clean isolated Windows client root rather than performed by the invited third party.",
+    "The invited tester remains useful post-release validation but is no longer a publication gate.",
+    "Bare-metal native Linux RTX 5090 lifecycle remains preview-only."
+  ]
+}

--- a/releases/v0.1.0-beta.1/manifest.json
+++ b/releases/v0.1.0-beta.1/manifest.json
@@ -1,33 +1,43 @@
 {
   "schema_version": 1,
   "release": "v0.1.0-beta.1",
-  "status": "candidate",
+  "status": "ready",
   "channel": "early-access",
   "audience": "invited-testers",
   "product": {
     "name": "OMP NInfer",
     "tagline": "Private Qwen coding appliance for RTX 5090",
     "repository": "https://github.com/alphastorm/omp-ninfer",
-    "profile": "../../profiles/qwen38-rtx5090-manual-tunnel.json"
+    "profile": "../../profiles/qwen38-rtx5090-windows-docker-local.json",
+    "primary_profile_id": "qwen38-rtx5090-windows-docker-local"
   },
   "components": {
     "omp": {
       "upstream_repository": "https://github.com/can1357/oh-my-pi",
       "upstream_tag": "v18.0.7",
       "upstream_commit": "6be4a1bec9c53ed9eef33e65a70a060970f30cce",
-      "release_id": "18.0.7-7b1dcc68daf9d8a4f901be7e2110ea86db37f719c6ecd20ed95a309d6fd347d8",
-      "distribution_version": "18.0.7-7b1dcc68",
-      "source_commit": "6d6ee173d86d8c537b019019ce9dbd149970f22f",
-      "artifact_name": "omp-18.0.7-7b1dcc68-darwin-arm64.tar.gz",
-      "artifact_url": "https://api.github.com/repos/alphastorm/homebrew-omp/releases/assets/532746724#omp-18.0.7-7b1dcc68-darwin-arm64.tar.gz",
-      "artifact_release_id": 378058103,
-      "artifact_asset_id": 532746724,
+      "component_repository": "https://github.com/alphastorm/homebrew-omp",
+      "component_release_tag": "omp-18.0.7-cross-platform-preview-5",
+      "component_release_id": 378212363,
+      "release_id": "18.0.7-cross-platform-preview-5",
+      "distribution_version": "18.0.7-cross-platform-preview-5",
+      "platform": "windows-x64",
+      "source_repository": "https://github.com/alphastorm/omp-monorepo",
+      "source_commit": "842366735b701bf0b15e26e31c5ca44928a0c608",
+      "qualification_commit": "aa0dee6db6cf5e61674577acacfe3ec8acdaea2c",
+      "main_commit": "ea28601524239eeff1a6a19b9a827c24fed756b3",
+      "source_tree": "fa6ed6a4e6ae3ebcba8f75781fa0b86ae2b9325e",
+      "artifact_name": "omp-18.0.7-windows-x64.tar.gz",
+      "artifact_url": "https://github.com/alphastorm/homebrew-omp/releases/download/omp-18.0.7-cross-platform-preview-5/omp-18.0.7-windows-x64.tar.gz",
+      "artifact_release_id": 378212363,
+      "artifact_asset_id": 533095343,
       "artifact_published": true,
-      "artifact_bytes": 121326128,
-      "artifact_sha256": "718934e50688983056fee023e0e5b9008453cdd9ce080c120470d7393ab3975a",
-      "homebrew_repository": "https://github.com/alphastorm/homebrew-omp",
-      "homebrew_cask": "omp-beta",
-      "homebrew_cask_revision": "88589a511b2a8a36439904b621d15ac2ac0f153c"
+      "artifact_bytes": 78452185,
+      "artifact_sha256": "4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7",
+      "binary_sha256": "0b59681010427a77aa39f7929576e270e91f8e8cc563a9f32f865090fc9ec892",
+      "compatibility_authority": "omp-ninfer-v0.1.0-beta.1-cross-platform-preview-9",
+      "compatibility_url": "https://github.com/alphastorm/omp-ninfer/blob/main/compatibility.json",
+      "compatibility_sha256": "225619d324c9e722002a4b7b48f3059f444460c5d981b16525e859414a8ea7bc"
     },
     "ninfer": {
       "repository": "https://github.com/alphastorm/ninfer",
@@ -64,23 +74,23 @@
   },
   "qualification": {
     "summary": "qualification.json",
-    "summary_sha256": null,
-    "public_url": null,
+    "summary_sha256": "b03806c042d0ac766c13a0f38b86614352759fc65142e58c9862430f449fe5f8",
+    "public_url": "https://raw.githubusercontent.com/alphastorm/omp-ninfer/f5ad3f2762889deca69daf2c7b35afa5e20f57f6/releases/v0.1.0-beta.1/qualification.json",
     "runtime_release_eligible": true,
-    "external_installation_passed": false
+    "external_installation_passed": true
   },
   "installation": {
-    "mode": "manual-ssh-tunnel",
+    "mode": "native-windows-docker-local",
     "quickstart": "../../docs/QUICKSTART.md",
     "managed_appliance_install": false,
     "silent_cloud_fallback": false
   },
   "limitations": [
     "Invited early access only; this is not a general-availability support claim.",
-    "Only the exact RTX 5090 Linux/WSL2 manual-tunnel profile is included.",
-    "The first beta does not use omp appliance install, managed upgrade, or appliance rollback.",
+    "The ready acceptance route is native Windows OMP with Docker Desktop WSL2 on an RTX 5090.",
+    "macOS managed SSH and native Linux clients remain preview profiles under compatibility.json.",
     "The NInfer container uses restart policy no; automatic restart and process-restart continuation are not claimed.",
-    "RTX 4090 support and multi-machine fleet claims are deferred.",
+    "RTX 4090 support, multi-GPU, and multi-tenant claims are deferred.",
     "Measured throughput and latency apply only to the recorded qualification machine and profile."
   ],
   "publication": {
@@ -88,14 +98,10 @@
     "targets": [
       "GitHub repository alphastorm/omp-ninfer",
       "GitHub prerelease v0.1.0-beta.1",
+      "Published OMP component omp-18.0.7-cross-platform-preview-5",
       "GitHub runtime tag alphastorm/ninfer@v0.1.0-qwen38-5090",
-      "GHCR immutable NInfer image",
-      "Homebrew cask omp-beta"
+      "GHCR immutable NInfer image"
     ],
-    "blockers": [
-      "Publish this qualification summary and record its SHA-256 and URL.",
-      "Run the clean external-install acceptance path using only published URLs.",
-      "Obtain bounded authority for the product tag, release, and final readiness effects."
-    ]
+    "blockers": []
   }
 }

--- a/releases/v0.1.0-beta.1/qualification.json
+++ b/releases/v0.1.0-beta.1/qualification.json
@@ -2,11 +2,11 @@
   "artifact_type": "omp_ninfer_product_qualification",
   "schema_version": 1,
   "release": "v0.1.0-beta.1",
-  "as_of": "2026-08-27",
+  "as_of": "2026-08-28",
   "status": "runtime-release-eligible",
   "publication_authorized": false,
-  "external_installation_qualified": false,
-  "scope": "One measured NVIDIA GeForce RTX 5090, the exact Qwen3.8 27B NInfer model artifact, the recorded BF16-KV MTP3 profile, and a later clean-source candidate identity proof. Component artifacts are published, but the external OMP/Homebrew installation path and another machine remain unqualified.",
+  "external_installation_qualified": true,
+  "scope": "One measured NVIDIA GeForce RTX 5090, the exact Qwen3.8 27B NInfer model artifact, the recorded BF16-KV MTP3 profile, clean-source candidate identity proof, and an owner-operated tester-equivalent clean native Windows installation using only public component URLs.",
   "runtime_identity": {
     "repository": "https://github.com/alphastorm/ninfer",
     "upstream_commit": "4eef14a7560d87a3ba717898e1d488a4c4c7246d",
@@ -69,6 +69,23 @@
       "release_eligible": true,
       "publication_authorized": false,
       "private_disposition_sha256": "fa299095dd98cb81fcf1891c3a1e128af4098b3168d7df2d4d2923531731b2ef"
+    },
+    "external_installation_acceptance": {
+      "status": "passed",
+      "operator_class": "owner-operated tester-equivalent",
+      "repository_path": "releases/v0.1.0-beta.1/acceptance/windows-owner-clean-install.json",
+      "public_url": "https://raw.githubusercontent.com/alphastorm/omp-ninfer/c08a2a98ddd2d1a369ffdfea4b7a0e552ba3e0c2/releases/v0.1.0-beta.1/acceptance/windows-owner-clean-install.json",
+      "sha256": "a8adb6bae314a05ec33d4549c50636762e0037a074199bdfda48816c0a8a6527",
+      "component_release_tag": "omp-18.0.7-cross-platform-preview-5",
+      "windows_asset_sha256": "4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7",
+      "windows_binary_sha256": "0b59681010427a77aa39f7929576e270e91f8e8cc563a9f32f865090fc9ec892",
+      "compatibility_authority": "omp-ninfer-v0.1.0-beta.1-cross-platform-preview-9",
+      "compatibility_sha256": "225619d324c9e722002a4b7b48f3059f444460c5d981b16525e859414a8ea7bc",
+      "tools": true,
+      "vision": true,
+      "stateful_resume": true,
+      "fail_closed": true,
+      "runtime_incumbent_restored": true
     }
   },
   "observed_gates": {
@@ -129,11 +146,11 @@
     "209.04 decode tokens/second is one measured server result, not a universal RTX 5090 or end-to-end OMP claim.",
     "The runtime lifecycle proved explicit re-promotion and exact incumbent restoration; it did not prove automatic restart or OMP appliance-level rollback.",
     "The exact NInfer image, binary package, SPDX SBOM, and checksums are publicly available and anonymously verified; this component publication does not authorize product readiness.",
+    "The owner-operated tester-equivalent native Windows clean install used only public client and compatibility URLs and passed tools, Vision, stateful resume, fail-closed behavior, and exact runtime restoration.",
     "Raw prompts, model outputs, private host identifiers, and raw request logs are excluded."
   ],
   "remaining_release_gates": [
-    "Run a clean external installation using only public release URLs and the manual-tunnel quickstart.",
     "Publish this qualification summary with its exact SHA-256 and URL.",
-    "Obtain explicit authority for the product tag, release, and final readiness effects."
+    "Create the explicitly authorized product tag and prerelease from the ready manifest."
   ]
 }

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -13,16 +13,19 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from render_compatibility import load_authority, render as render_compatibility_matrix
+from render_compatibility import (  # pyright: ignore[reportMissingImports]
+    load_authority,
+    render as render_compatibility_matrix,
+)
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 OCI_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 OMP_RELEASE_ID_RE = re.compile(
-    r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<identity>[0-9a-f]{64})$"
+    r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-cross-platform-preview-(?P<preview>[1-9][0-9]*)$"
 )
-OMP_ASSET_PATH_RE = re.compile(
-    r"^/repos/alphastorm/homebrew-omp/releases/assets/(?P<asset_id>[1-9][0-9]*)$"
+OMP_ASSET_DOWNLOAD_RE = re.compile(
+    r"^/alphastorm/homebrew-omp/releases/download/(?P<tag>[^/]+)/(?P<name>[^/]+)$"
 )
 PRIVATE_MARKERS = (
     "/Users/",
@@ -177,18 +180,21 @@ def validate(
 
     require(profile.get("schema_version") == 1, "profile schema_version must be 1", errors)
     require(profile.get("release") == release, "profile release must match manifest release", errors)
-    require(profile.get("profile_id") == "qwen38-rtx5090-manual-tunnel",
-            "profile_id must be qwen38-rtx5090-manual-tunnel", errors)
-    require(profile.get("installation_mode") == "manual-ssh-tunnel",
-            "profile installation_mode must be manual-ssh-tunnel", errors)
+    expected_profile_id = product.get("primary_profile_id") if isinstance(product, dict) else None
+    installation_mode = manifest.get("installation", {}).get("mode")
+    require(isinstance(expected_profile_id, str) and profile.get("profile_id") == expected_profile_id,
+            "profile_id must match manifest product.primary_profile_id", errors)
+    require(isinstance(installation_mode, str)
+            and profile.get("installation_mode") == installation_mode,
+            "profile installation_mode must match manifest installation.mode", errors)
 
     transport = profile.get("transport", {})
     require(transport.get("client_bind_host") == "127.0.0.1",
-            "client tunnel endpoint must bind loopback", errors)
+            "client endpoint must bind loopback", errors)
     require(transport.get("runtime_bind_host") == "127.0.0.1",
             "runtime endpoint must bind loopback", errors)
     require(transport.get("client_port") == transport.get("runtime_port") == 18089,
-            "profile tunnel ports must both be 18089", errors)
+            "profile loopback ports must both be 18089", errors)
     require(transport.get("silent_cloud_fallback") is False,
             "profile must disable silent cloud fallback", errors)
 
@@ -223,7 +229,7 @@ def validate(
     require(omp_provider.get("api") == "openai-responses",
             "OMP provider API must be openai-responses", errors)
     require(omp_provider.get("base_url") == "http://127.0.0.1:18089/v1",
-            "OMP provider must use the local tunnel endpoint", errors)
+            "OMP provider must use the local loopback endpoint", errors)
     require(omp_provider.get("request_model_id") == "q38-ninfer",
             "OMP provider request model must be q38-ninfer", errors)
     require(omp_provider.get("ninfer_stateful_responses") is True,
@@ -255,8 +261,39 @@ def validate(
         composition = compatibility.get("composition", {})
         require_git_sha(composition.get("lifecycle_source_commit"),
                         "compatibility composition.lifecycle_source_commit", errors)
+        require_git_sha(composition.get("qualification_source_commit"),
+                        "compatibility composition.qualification_source_commit", errors)
+        require_git_sha(composition.get("lifecycle_main_commit"),
+                        "compatibility composition.lifecycle_main_commit", errors)
+        require_git_sha(composition.get("lifecycle_main_tree"),
+                        "compatibility composition.lifecycle_main_tree", errors)
         require_git_sha(composition.get("request_compatibility_source_commit"),
                         "compatibility composition.request_compatibility_source_commit", errors)
+        require(compatibility.get("authority_id") == omp.get("compatibility_authority"),
+                "OMP component must bind the checked-in compatibility authority", errors)
+        require_sha(omp.get("compatibility_sha256"),
+                    "components.omp.compatibility_sha256", errors)
+        require(omp.get("compatibility_sha256") == sha256_file(compatibility_path),
+                "OMP compatibility SHA-256 must match compatibility.json", errors)
+        require(composition.get("lifecycle_source_commit") == omp.get("source_commit"),
+                "OMP source commit must match compatibility composition", errors)
+        require(composition.get("qualification_source_commit") == omp.get("qualification_commit"),
+                "OMP qualification commit must match compatibility composition", errors)
+        require(composition.get("lifecycle_main_commit") == omp.get("main_commit"),
+                "OMP main commit must match compatibility composition", errors)
+        require(composition.get("lifecycle_generated_lock_tree") == omp.get("source_tree"),
+                "OMP source tree must match compatibility final tree", errors)
+        primary_client = next(
+            (item.get("client_distribution", {}) for item in compatibility.get("profiles", [])
+             if item.get("id") == "windows-docker-local"),
+            {},
+        )
+        require(primary_client.get("archive_sha256") == omp.get("artifact_sha256"),
+                "OMP Windows artifact must match compatibility authority", errors)
+        require(primary_client.get("binary_sha256") == omp.get("binary_sha256"),
+                "OMP Windows binary must match compatibility authority", errors)
+        require(primary_client.get("asset_url") == omp.get("artifact_url"),
+                "OMP Windows asset URL must match compatibility authority", errors)
         for profile_item in compatibility.get("profiles", []):
             profile_id = profile_item.get("id", "<unknown>")
             profile_runtime = profile_item.get("runtime", {})
@@ -281,6 +318,9 @@ def validate(
         require_git_sha(ninfer.get(key), f"components.ninfer.{key}", errors)
     require_git_sha(omp.get("upstream_commit"), "components.omp.upstream_commit", errors)
     require_git_sha(omp.get("source_commit"), "components.omp.source_commit", errors)
+    require_git_sha(omp.get("qualification_commit"), "components.omp.qualification_commit", errors)
+    require_git_sha(omp.get("main_commit"), "components.omp.main_commit", errors)
+    require_git_sha(omp.get("source_tree"), "components.omp.source_tree", errors)
     omp_release_id = omp.get("release_id")
     omp_release_match = (
         OMP_RELEASE_ID_RE.fullmatch(omp_release_id)
@@ -288,53 +328,61 @@ def validate(
         else None
     )
     require(omp_release_match is not None,
-            "components.omp.release_id must bind a semantic version and 64-hex identity", errors)
+            "components.omp.release_id must be a cross-platform preview identity", errors)
     if omp_release_match is not None:
         omp_version = omp_release_match.group("version")
-        omp_identity = omp_release_match.group("identity")
-        expected_distribution_version = f"{omp_version}-{omp_identity[:8]}"
         require(omp.get("upstream_tag") == f"v{omp_version}",
                 "OMP release ID version must match upstream_tag", errors)
-        require(omp.get("distribution_version") == expected_distribution_version,
-                "OMP distribution version must derive from release_id", errors)
-    omp_distribution_version = omp.get("distribution_version")
+        require(omp.get("distribution_version") == omp_release_id,
+                "OMP distribution version must equal release_id", errors)
+        require(omp.get("component_release_tag") == f"omp-{omp_release_id}",
+                "OMP component tag must derive from release_id", errors)
+    omp_platform = omp.get("platform")
+    require(omp_platform == "windows-x64",
+            "ready OMP primary platform must be windows-x64", errors)
     expected_omp_artifact_name = (
-        f"omp-{omp_distribution_version}-darwin-arm64.tar.gz"
-        if isinstance(omp_distribution_version, str)
+        f"omp-{omp_release_match.group('version')}-{omp_platform}.tar.gz"
+        if omp_release_match is not None and isinstance(omp_platform, str)
         else None
     )
     require(omp.get("artifact_name") == expected_omp_artifact_name,
-            "OMP artifact name must bind distribution_version and darwin-arm64", errors)
+            "OMP artifact name must bind release version and primary platform", errors)
+    require(omp.get("component_repository") == "https://github.com/alphastorm/homebrew-omp",
+            "OMP component repository must be alphastorm/homebrew-omp", errors)
+    require(omp.get("source_repository") == "https://github.com/alphastorm/omp-monorepo",
+            "OMP source repository must be alphastorm/omp-monorepo", errors)
+    require(isinstance(omp.get("component_release_id"), int)
+            and omp.get("component_release_id", 0) > 0,
+            "OMP component_release_id must be positive", errors)
     require(isinstance(omp.get("artifact_release_id"), int)
             and omp.get("artifact_release_id", 0) > 0,
             "OMP artifact_release_id must be positive", errors)
+    require(omp.get("component_release_id") == omp.get("artifact_release_id"),
+            "OMP component and artifact release IDs must match", errors)
     require(isinstance(omp.get("artifact_asset_id"), int)
             and omp.get("artifact_asset_id", 0) > 0,
             "OMP artifact_asset_id must be positive", errors)
     require(isinstance(omp.get("artifact_published"), bool),
             "OMP artifact_published must be boolean", errors)
     require_sha(omp.get("artifact_sha256"), "components.omp.artifact_sha256", errors)
+    require_sha(omp.get("binary_sha256"), "components.omp.binary_sha256", errors)
     require(isinstance(omp.get("artifact_bytes"), int) and omp.get("artifact_bytes", 0) > 0,
             "OMP artifact_bytes must be positive", errors)
-    require(omp.get("homebrew_repository") == "https://github.com/alphastorm/homebrew-omp",
-            "OMP Homebrew repository must be alphastorm/homebrew-omp", errors)
-    require(omp.get("homebrew_cask") == "omp-beta",
-            "OMP Homebrew cask must be omp-beta", errors)
     omp_artifact_url = omp.get("artifact_url")
     require_https(omp_artifact_url, "components.omp.artifact_url", errors, nullable=True)
     if isinstance(omp_artifact_url, str):
         parsed_omp_url = urlparse(omp_artifact_url)
-        omp_asset_path_match = OMP_ASSET_PATH_RE.fullmatch(parsed_omp_url.path)
+        omp_asset_path_match = OMP_ASSET_DOWNLOAD_RE.fullmatch(parsed_omp_url.path)
         require(
             parsed_omp_url.scheme == "https"
-            and parsed_omp_url.netloc == "api.github.com"
+            and parsed_omp_url.netloc == "github.com"
             and omp_asset_path_match is not None
-            and int(omp_asset_path_match.group("asset_id"))
-            == omp.get("artifact_asset_id")
+            and omp_asset_path_match.group("tag") == omp.get("component_release_tag")
+            and omp_asset_path_match.group("name") == omp.get("artifact_name")
             and parsed_omp_url.params == ""
             and parsed_omp_url.query == ""
-            and parsed_omp_url.fragment == omp.get("artifact_name"),
-            "OMP artifact URL must bind the private Homebrew release asset and artifact name",
+            and parsed_omp_url.fragment == "",
+            "OMP artifact URL must bind the public component tag and artifact name",
             errors,
         )
     for key in ("source_archive_sha256", "server_binary_sha256"):
@@ -387,6 +435,37 @@ def validate(
             "qualification must record runtime-release-eligible", errors)
     require(qualification.get("publication_authorized") is False,
             "checked-in qualification must not grant publication authority", errors)
+    external_acceptance = qualification.get("composition", {}).get("external_installation_acceptance", {})
+    if qualification.get("external_installation_qualified") is True:
+        require(external_acceptance.get("status") == "passed",
+                "external installation acceptance must pass", errors)
+        acceptance_ref = external_acceptance.get("repository_path")
+        require(isinstance(acceptance_ref, str),
+                "external acceptance repository_path must be present", errors)
+        acceptance_path = (root / acceptance_ref).resolve() if isinstance(acceptance_ref, str) else root
+        require(acceptance_path.is_relative_to(root.resolve()),
+                "external acceptance path must stay inside the repository", errors)
+        require(acceptance_path.is_file(), "external acceptance receipt must exist", errors)
+        require_sha(external_acceptance.get("sha256"),
+                    "external acceptance SHA-256", errors)
+        if acceptance_path.is_file() and isinstance(external_acceptance.get("sha256"), str):
+            require(sha256_file(acceptance_path) == external_acceptance.get("sha256"),
+                    "external acceptance SHA-256 must match receipt bytes", errors)
+        require_https(external_acceptance.get("public_url"),
+                      "external acceptance public_url", errors)
+        require(external_acceptance.get("component_release_tag") == omp.get("component_release_tag"),
+                "external acceptance component tag must match manifest", errors)
+        require(external_acceptance.get("windows_asset_sha256") == omp.get("artifact_sha256"),
+                "external acceptance Windows archive must match manifest", errors)
+        require(external_acceptance.get("windows_binary_sha256") == omp.get("binary_sha256"),
+                "external acceptance Windows binary must match manifest", errors)
+        require(external_acceptance.get("compatibility_authority") == omp.get("compatibility_authority"),
+                "external acceptance compatibility authority must match manifest", errors)
+        require(external_acceptance.get("compatibility_sha256") == omp.get("compatibility_sha256"),
+                "external acceptance compatibility SHA-256 must match manifest", errors)
+        for key in ("tools", "vision", "stateful_resume", "fail_closed", "runtime_incumbent_restored"):
+            require(external_acceptance.get(key) is True,
+                    f"external acceptance must pass {key}", errors)
 
     expected_summary_sha = manifest_qualification.get("summary_sha256")
     require_sha(expected_summary_sha, "qualification.summary_sha256", errors, nullable=True)
@@ -419,7 +498,13 @@ def validate(
     if status in {"candidate", "ready"} or require_installable or require_ready:
         installable_values = {
             "components.omp.distribution_version": omp.get("distribution_version"),
+            "components.omp.platform": omp.get("platform"),
             "components.omp.source_commit": omp.get("source_commit"),
+            "components.omp.qualification_commit": omp.get("qualification_commit"),
+            "components.omp.main_commit": omp.get("main_commit"),
+            "components.omp.source_tree": omp.get("source_tree"),
+            "components.omp.component_release_tag": omp.get("component_release_tag"),
+            "components.omp.component_release_id": omp.get("component_release_id"),
             "components.omp.artifact_name": omp.get("artifact_name"),
             "components.omp.artifact_url": omp.get("artifact_url"),
             "components.omp.artifact_release_id": omp.get("artifact_release_id"),
@@ -427,7 +512,8 @@ def validate(
             "components.omp.artifact_published": omp.get("artifact_published"),
             "components.omp.artifact_bytes": omp.get("artifact_bytes"),
             "components.omp.artifact_sha256": omp.get("artifact_sha256"),
-            "components.omp.homebrew_cask_revision": omp.get("homebrew_cask_revision"),
+            "components.omp.binary_sha256": omp.get("binary_sha256"),
+            "components.omp.compatibility_sha256": omp.get("compatibility_sha256"),
             "components.ninfer.oci_reference": ninfer.get("oci_reference"),
             "components.ninfer.oci_manifest_digest": ninfer.get("oci_manifest_digest"),
             "components.ninfer.sbom_url": ninfer.get("sbom_url"),
@@ -439,8 +525,6 @@ def validate(
                 "installable release requires a published OMP artifact", errors)
         require(local_packaging.get("published") is True,
                 "installable release requires published NInfer packaging", errors)
-        require_git_sha(omp.get("homebrew_cask_revision"),
-                        "components.omp.homebrew_cask_revision", errors, nullable=True)
         require(isinstance(ninfer.get("oci_reference"), str)
                 and "@sha256:" in ninfer.get("oci_reference", ""),
                 "ready NInfer OCI reference must be digest-pinned", errors)

--- a/tests/test_manual_tunnel_scripts.py
+++ b/tests/test_manual_tunnel_scripts.py
@@ -14,6 +14,32 @@ EXAMPLES = ROOT / "examples" / "manual-tunnel"
 
 
 class ManualTunnelScriptsTest(unittest.TestCase):
+    def test_windows_ready_path_materializes_key_and_refuses_overwrite(self) -> None:
+        quickstart = (ROOT / "docs" / "QUICKSTART.md").read_text(encoding="utf-8")
+        provider = quickstart.split("### Native Windows OMP", 1)[1].split(
+            "The sealed launcher owns config selection", 1
+        )[0]
+        self.assertIn("wsl.exe -d Ubuntu-24.04", provider)
+        self.assertIn("$HOME/.config/omp-ninfer/api-key", provider)
+        self.assertIn("[IO.File]::WriteAllText($KeyPath", provider)
+        self.assertIn("icacls.exe $KeyPath /inheritance:r", provider)
+        self.assertIn("Existing OMP models/config found", provider)
+        self.assertIn("Copy-Item .\\examples\\manual-tunnel\\fail-closed.yml", provider)
+        self.assertIn("$env:NINFER_BETA_API_KEY", provider)
+        self.assertNotIn("install -m", provider)
+        self.assertLess(
+            provider.index("Existing OMP models/config found"),
+            provider.index("Copy-Item .\\examples\\windows-docker-local"),
+        )
+
+        acceptance = quickstart.split("### Native Windows command forms", 1)[1].split(
+            "### macOS/Linux command forms", 1
+        )[0]
+        self.assertIn("$env:LOCALAPPDATA\\OMP\\omp.cmd", acceptance)
+        self.assertIn("stop-ninfer.sh", acceptance)
+        self.assertIn("if ($LASTEXITCODE -eq 0)", acceptance)
+        self.assertNotIn("Stop the tunnel", acceptance)
+
     @staticmethod
     def copy_contract_tree(root: Path) -> None:
         for directory in ("examples", "profiles", "releases", "scripts"):

--- a/tests/test_manual_tunnel_scripts.py
+++ b/tests/test_manual_tunnel_scripts.py
@@ -89,31 +89,6 @@ class ManualTunnelScriptsTest(unittest.TestCase):
             model = root / "model.ninfer"
             with model.open("wb") as model_file:
                 model_file.truncate(manifest["components"]["model"]["artifact_bytes"])
-            manifest["status"] = "candidate"
-            omp_artifact_name = manifest["components"]["omp"]["artifact_name"]
-            manifest["components"]["omp"].update(
-                {
-                    "artifact_url": (
-                        "https://api.github.com/repos/alphastorm/homebrew-omp/"
-                        f"releases/assets/123456789#{omp_artifact_name}"
-                    ),
-                    "artifact_asset_id": 123456789,
-                    "artifact_published": True,
-                    "homebrew_cask_revision": "c" * 40,
-                }
-            )
-            oci_manifest_digest = manifest["components"]["ninfer"][
-                "oci_manifest_digest"
-            ]
-            manifest["components"]["ninfer"].update(
-                {
-                    "oci_reference": f"ghcr.io/alphastorm/ninfer@{oci_manifest_digest}",
-                    "sbom_url": "https://example.test/ninfer.spdx.json",
-                }
-            )
-            manifest_path.write_text(
-                json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
-            )
 
             key = root / "api-key"
             key.write_text("test-key\n", encoding="utf-8")

--- a/tests/test_verify_release.py
+++ b/tests/test_verify_release.py
@@ -36,36 +36,25 @@ class ReleaseContractTest(unittest.TestCase):
     def save(path: Path, value: dict) -> None:
         path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
 
-    @staticmethod
-    def bind_installable_components(manifest: dict) -> None:
-        omp = manifest["components"]["omp"]
-        artifact_name = omp["artifact_name"]
-        manifest["components"]["omp"].update(
-            {
-                "artifact_url": (
-                    "https://api.github.com/repos/alphastorm/homebrew-omp/"
-                    f"releases/assets/123456789#{artifact_name}"
-                ),
-                "artifact_asset_id": 123456789,
-                "artifact_published": True,
-                "homebrew_cask_revision": "c" * 40,
-            }
-        )
-        oci_manifest_digest = manifest["components"]["ninfer"]["oci_manifest_digest"]
-        manifest["components"]["ninfer"].update(
-            {
-                "oci_reference": f"ghcr.io/alphastorm/ninfer@{oci_manifest_digest}",
-                "sbom_url": "https://github.com/alphastorm/ninfer/releases/download/v0.1.0-qwen38-5090/ninfer.spdx.json",
-            }
-        )
+    def make_candidate(self, root: Path, manifest: dict) -> None:
+        qualification_path = root / "releases" / "v0.1.0-beta.1" / "qualification.json"
+        qualification = self.load(qualification_path)
+        qualification["external_installation_qualified"] = False
+        self.save(qualification_path, qualification)
+        manifest["qualification"]["summary_sha256"] = hashlib.sha256(
+            qualification_path.read_bytes()
+        ).hexdigest()
+        manifest["status"] = "candidate"
+        manifest["qualification"]["external_installation_passed"] = False
+        manifest["publication"]["blockers"] = ["Run the external-install acceptance path."]
 
-    def test_checked_in_candidate_is_installable_but_not_ready(self) -> None:
+    def test_checked_in_ready_release_is_installable(self) -> None:
         manifest, errors = VERIFY_RELEASE.validate(ROOT, require_ready=False)
-        self.assertEqual(manifest["status"], "candidate")
+        self.assertEqual(manifest["status"], "ready")
         self.assertEqual(errors, [])
 
         _, ready_errors = VERIFY_RELEASE.validate(ROOT, require_ready=True)
-        self.assertIn("release manifest is not ready", ready_errors)
+        self.assertEqual(ready_errors, [])
 
         _, installable_errors = VERIFY_RELEASE.validate(
             ROOT,
@@ -81,6 +70,7 @@ class ReleaseContractTest(unittest.TestCase):
         manifest = self.load(manifest_path)
         manifest["status"] = "draft"
         manifest["components"]["omp"]["artifact_published"] = False
+        manifest["publication"]["blockers"] = ["Draft release is not installable."]
         self.save(manifest_path, manifest)
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
@@ -95,8 +85,7 @@ class ReleaseContractTest(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
         manifest = self.load(manifest_path)
-        manifest["status"] = "candidate"
-        self.bind_installable_components(manifest)
+        self.make_candidate(root, manifest)
         self.save(manifest_path, manifest)
 
         _, errors = VERIFY_RELEASE.validate(
@@ -107,40 +96,24 @@ class ReleaseContractTest(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_ready_contract_accepts_complete_immutable_identities(self) -> None:
-        temporary, root = self.candidate_copy()
-        self.addCleanup(temporary.cleanup)
-        manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
-        qualification_path = root / "releases" / "v0.1.0-beta.1" / "qualification.json"
-        manifest = self.load(manifest_path)
-        qualification = self.load(qualification_path)
-
-        qualification["external_installation_qualified"] = True
-        self.save(qualification_path, qualification)
-        qualification_sha = hashlib.sha256(qualification_path.read_bytes()).hexdigest()
-
-        manifest["status"] = "ready"
-        self.bind_installable_components(manifest)
-        manifest["qualification"].update(
-            {
-                "summary_sha256": qualification_sha,
-                "public_url": "https://github.com/alphastorm/omp-ninfer/releases/download/v0.1.0-beta.1/qualification.json",
-                "external_installation_passed": True,
-            }
-        )
-        manifest["publication"]["blockers"] = []
-        self.save(manifest_path, manifest)
-
-        _, errors = VERIFY_RELEASE.validate(root, require_ready=True)
+        _, errors = VERIFY_RELEASE.validate(ROOT, require_ready=True)
         self.assertEqual(errors, [])
 
     def test_ready_contract_rejects_incomplete_publication(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
+        qualification_path = root / "releases" / "v0.1.0-beta.1" / "qualification.json"
         manifest = self.load(manifest_path)
+        qualification = self.load(qualification_path)
         manifest["status"] = "ready"
         manifest["components"]["omp"]["artifact_url"] = None
+        manifest["qualification"]["summary_sha256"] = None
+        manifest["qualification"]["public_url"] = None
+        manifest["qualification"]["external_installation_passed"] = False
         manifest["publication"]["blockers"] = []
+        qualification["external_installation_qualified"] = False
+        self.save(qualification_path, qualification)
         self.save(manifest_path, manifest)
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=True)
@@ -151,7 +124,7 @@ class ReleaseContractTest(unittest.TestCase):
     def test_cross_component_model_hash_drift_is_rejected(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
-        profile_path = root / "profiles" / "qwen38-rtx5090-manual-tunnel.json"
+        profile_path = root / "profiles" / "qwen38-rtx5090-windows-docker-local.json"
         profile = self.load(profile_path)
         profile["model"]["artifact_sha256"] = "0" * 64
         self.save(profile_path, profile)
@@ -162,7 +135,7 @@ class ReleaseContractTest(unittest.TestCase):
     def test_profile_rejects_container_private_loopback_networking(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
-        profile_path = root / "profiles" / "qwen38-rtx5090-manual-tunnel.json"
+        profile_path = root / "profiles" / "qwen38-rtx5090-windows-docker-local.json"
         profile = self.load(profile_path)
         profile["server"]["container_network_mode"] = "bridge"
         self.save(profile_path, profile)
@@ -183,7 +156,7 @@ class ReleaseContractTest(unittest.TestCase):
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
         self.assertIn("model artifact URL must bind repository, revision, and name", errors)
 
-    def test_omp_distribution_version_must_derive_from_release_id(self) -> None:
+    def test_omp_distribution_version_must_equal_release_id(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
@@ -192,9 +165,9 @@ class ReleaseContractTest(unittest.TestCase):
         self.save(manifest_path, manifest)
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
-        self.assertIn("OMP distribution version must derive from release_id", errors)
+        self.assertIn("OMP distribution version must equal release_id", errors)
 
-    def test_omp_artifact_name_must_bind_distribution_version(self) -> None:
+    def test_omp_artifact_name_must_bind_version_and_platform(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
@@ -204,26 +177,25 @@ class ReleaseContractTest(unittest.TestCase):
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
         self.assertIn(
-            "OMP artifact name must bind distribution_version and darwin-arm64",
+            "OMP artifact name must bind release version and primary platform",
             errors,
         )
 
-    def test_candidate_omp_asset_url_must_bind_private_asset_name(self) -> None:
+    def test_candidate_omp_asset_url_must_bind_public_component(self) -> None:
         temporary, root = self.candidate_copy()
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
         manifest = self.load(manifest_path)
-        manifest["status"] = "candidate"
-        self.bind_installable_components(manifest)
+        self.make_candidate(root, manifest)
         manifest["components"]["omp"]["artifact_url"] = (
-            "https://api.github.com/repos/alphastorm/homebrew-omp/"
-            "releases/assets/123456789#wrong.tar.gz"
+            "https://github.com/alphastorm/homebrew-omp/releases/download/"
+            "omp-18.0.7-cross-platform-preview-5/wrong.tar.gz"
         )
         self.save(manifest_path, manifest)
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
         self.assertIn(
-            "OMP artifact URL must bind the private Homebrew release asset and artifact name",
+            "OMP artifact URL must bind the public component tag and artifact name",
             errors,
         )
 
@@ -232,8 +204,7 @@ class ReleaseContractTest(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
         manifest = self.load(manifest_path)
-        manifest["status"] = "candidate"
-        self.bind_installable_components(manifest)
+        self.make_candidate(root, manifest)
         manifest["components"]["omp"]["artifact_published"] = False
         self.save(manifest_path, manifest)
 
@@ -250,8 +221,7 @@ class ReleaseContractTest(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
         manifest = self.load(manifest_path)
-        manifest["status"] = "candidate"
-        self.bind_installable_components(manifest)
+        self.make_candidate(root, manifest)
         manifest["components"]["ninfer"]["oci_manifest_digest"] = f"sha256:{'f' * 64}"
         self.save(manifest_path, manifest)
 


### PR DESCRIPTION
## Ready transition
- replace the candidate-only macOS package contract with the accepted native Windows component
- bind owner-operated tester-equivalent clean-install evidence from public URLs
- add the exact Windows Docker Desktop WSL2 ready profile
- make `--require-ready` the checked-in passing contract
- date the beta changelog and publish tagged Windows-first quickstart instructions

## Exact accepted identities
- ready commit: `bc2ddfdd4d0194bd1ad54bfa49f1815a5ed78bd2`
- OMP component: `omp-18.0.7-cross-platform-preview-5`
- Windows archive: `4d94ffd7761558691cc5381d56069ea9d3bd2b081d37ce5afbaf2c05ef9af5a7`
- Windows binary: `0b59681010427a77aa39f7929576e270e91f8e8cc563a9f32f865090fc9ec892`
- compatibility authority: `omp-ninfer-v0.1.0-beta.1-cross-platform-preview-9`
- NInfer image: `sha256:a19e00c5d7993d7c12341974bdc7e3d13e61d9deaf39e8ce00cf94abd6137712`
- model: `eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e`

## Acceptance
Clean native Windows install passed archive/binary/compatibility checks, exact version, Docker/GPU doctor, status, authenticated file tool, Vision, stateful exit/resume, runtime-outage fail closed, no cloud fallback, and exact NYC production restoration.

## Verification
- `python3 scripts/verify_release.py --require-ready --json`: valid ready manifest
- 26/26 product tests
- shell launcher parse checks
- Pyright and JSON diagnostics clean

The invited tester remains post-release validation; newly discovered non-integrity defects move to the next release.
