### PR TITLE
chore: pay down settings and hygiene debt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -53,7 +53,7 @@ section 7 and the **Native Windows command forms** at the start of section 8.
 
 ## Managed macOS SSH preview route
 
-## Prerequisites
+### Prerequisites
 
 **Mac**
 


### PR DESCRIPTION
Quickstart macOS-route heading level fix (duplicate H2 broke the doc outline) and monthly Dependabot updates for the SHA-pinned actions. Verified: verify_release --require-ready pass, 32 tests OK.