### PR TITLE
feat(release): prepare v0.2 integration tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Integrated the scripted SM120/MTP3 profiler and its retained experiment packets into NInfer
+  mainline together with the latest direct upstream runtime changes.
 - Rewrote the README around the product value proposition: stateful GPU-resident sessions,
   fail-closed privacy, verifiable release identity, a runtime comparison table, and the NInfer
   family lineage.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,9 +39,9 @@ number kernel work is judged against.
 
 ## The profiling lane
 
-Branch
-[`perf/scripted-sm120-mtp3-profiling`](https://github.com/alphastorm/ninfer/tree/perf/scripted-sm120-mtp3-profiling)
-in the runtime repo turns one-off profiling into reproducible packets:
+Runtime mainline commit
+[`7c1c1936`](https://github.com/alphastorm/ninfer/tree/7c1c1936d1fd8b645bc7a30cdcbe35cc6b12c206/tools/bench)
+turns one-off profiling into reproducible packets without a long-lived controller branch:
 
 - `tools/bench/run_sm120_mtp3_profile.sh` — orchestrates Nsight Compute, Nsight Systems, and
   timing captures for the MTP3 decode loop with container isolation and performance-counter
@@ -80,7 +80,8 @@ Entry detail:
   pair kernels show decode (`M=1`) already at 75.2% of the measured read peak, and the 4-token
   verification batch moving the same bytes. Conclusion: speculative verification is
   bandwidth-amortized; acceptance rate, not verify cost, is the lever. Packets:
-  `profiles/` on the profiling branch.
+  [`profiles/`](https://github.com/alphastorm/ninfer/tree/7c1c1936d1fd8b645bc7a30cdcbe35cc6b12c206/profiles)
+  at the integrated mainline commit.
 - **EXP-002 — negative result, kept on the record.** The MMA candidate for the Q5 post-mixer was
   triaged `more-than-50-percent-slower` and rejected; SIMT split-2 remains production. Negative
   results are part of the ledger so the next contributor does not re-run the same dead end.

--- a/scripts/compare_responses_wire.py
+++ b/scripts/compare_responses_wire.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Normalize and compare two sanitized OpenAI Responses wire captures."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+ARTIFACT_TYPE = "omp_ninfer_responses_wire_capture"
+ID_RE = re.compile(r"^(?P<prefix>[A-Za-z][A-Za-z0-9]*)(?:_|-)[0-9A-Za-z-]{8,}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+TERMINAL_EVENTS = {"response.completed", "response.failed", "response.incomplete"}
+SECRET_HEADERS = {"authorization", "x-api-key", "x-ninfer-session"}
+TIMESTAMP_KEYS = {"created_at", "completed_at", "timestamp", "timestamp_unix_ms"}
+
+
+class CaptureError(ValueError):
+    pass
+
+
+@dataclass
+class Normalizer:
+    workspace: Path | None = None
+    ids: dict[str, str] = field(default_factory=dict)
+    digests: dict[str, str] = field(default_factory=dict)
+
+    def token(self, value: str) -> str:
+        match = ID_RE.fullmatch(value)
+        if match is None:
+            return value
+        existing = self.ids.get(value)
+        if existing is not None:
+            return existing
+        prefix = match.group("prefix").lower()
+        token = f"<{prefix}:{sum(item.startswith(f'<{prefix}:') for item in self.ids.values()) + 1}>"
+        self.ids[value] = token
+        return token
+
+    def digest(self, value: str) -> str:
+        existing = self.digests.get(value)
+        if existing is not None:
+            return existing
+        token = f"<digest:{len(self.digests) + 1}>"
+        self.digests[value] = token
+        return token
+
+
+def require_capture(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise CaptureError(f"{label}: capture root must be an object")
+    if value.get("artifact_type") != ARTIFACT_TYPE or value.get("schema_version") != 1:
+        raise CaptureError(f"{label}: unsupported capture identity")
+    if not isinstance(value.get("scenario"), str) or not value["scenario"]:
+        raise CaptureError(f"{label}: scenario must be a non-empty string")
+    for key in ("requests", "events"):
+        if not isinstance(value.get(key), list) or not all(
+            isinstance(item, dict) for item in value[key]
+        ):
+            raise CaptureError(f"{label}: {key} must be an array of objects")
+    return value
+
+
+def normalize_value(
+    value: Any,
+    normalizer: Normalizer,
+    *,
+    key: str | None = None,
+    in_usage: bool = False,
+) -> Any:
+    if key in TIMESTAMP_KEYS and isinstance(value, (int, float, str)):
+        return "<timestamp>"
+    if in_usage and isinstance(value, (int, float)) and not isinstance(value, bool):
+        return "<number>"
+    if isinstance(value, str):
+        lowered = key.lower() if key else ""
+        if lowered in SECRET_HEADERS:
+            if not value:
+                raise CaptureError(f"credential header {key} is empty")
+            return "<present>"
+        if lowered in {"ninfer_session", "ninfer_request_id"} and SHA256_RE.fullmatch(value):
+            return normalizer.digest(value)
+        if normalizer.workspace is not None:
+            workspace = str(normalizer.workspace)
+            if workspace and workspace in value:
+                value = value.replace(workspace, "<workspace>")
+        if lowered == "id" or lowered.endswith("_id") or lowered in {
+            "previous_response_id",
+            "call_id",
+            "response_id",
+            "item_id",
+        }:
+            return normalizer.token(value)
+        return value
+    if isinstance(value, list):
+        return [normalize_value(item, normalizer, in_usage=in_usage) for item in value]
+    if isinstance(value, dict):
+        output: dict[str, Any] = {}
+        for child_key in sorted(value):
+            child_usage = in_usage or child_key == "usage"
+            output[child_key] = normalize_value(
+                value[child_key], normalizer, key=child_key, in_usage=child_usage
+            )
+        return output
+    return value
+
+
+def event_response_id(event: dict[str, Any]) -> str | None:
+    direct = event.get("response_id")
+    if isinstance(direct, str):
+        return direct
+    response = event.get("response")
+    if isinstance(response, dict) and isinstance(response.get("id"), str):
+        return response["id"]
+    return None
+
+
+def validate_events(events: list[dict[str, Any]], label: str) -> list[str]:
+    errors: list[str] = []
+    if not events:
+        return [f"{label}: events are empty"]
+    types = [event.get("type") for event in events]
+    if types[0] != "response.created":
+        errors.append(f"{label}: first event must be response.created")
+    if types[-1] not in TERMINAL_EVENTS:
+        errors.append(f"{label}: final event must be terminal")
+
+    sequences = [event.get("sequence_number") for event in events]
+    if not all(isinstance(number, int) and not isinstance(number, bool) for number in sequences):
+        errors.append(f"{label}: every event needs an integer sequence_number")
+    else:
+        sequence_numbers = [cast(int, number) for number in sequences]
+        if any(
+            right != left + 1
+            for left, right in zip(sequence_numbers, sequence_numbers[1:])
+        ):
+            errors.append(f"{label}: sequence_number values must be contiguous")
+
+    response_ids = {value for event in events if (value := event_response_id(event)) is not None}
+    if len(response_ids) != 1:
+        errors.append(f"{label}: events must retain one response id")
+
+    added: set[str] = set()
+    done: set[str] = set()
+    for event in events:
+        item = event.get("item")
+        item_id = item.get("id") if isinstance(item, dict) else None
+        if event.get("type") == "response.output_item.added" and isinstance(item_id, str):
+            added.add(item_id)
+        if event.get("type") == "response.output_item.done" and isinstance(item_id, str):
+            done.add(item_id)
+    if added != done:
+        errors.append(f"{label}: output item ids differ between added and done events")
+    return errors
+
+
+def normalize_capture(
+    capture: dict[str, Any], *, workspace: Path | None = None
+) -> dict[str, Any]:
+    normalizer = Normalizer(workspace=workspace.resolve() if workspace else None)
+    return normalize_value(capture, normalizer)
+
+
+def compare_captures(
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    reference_workspace: Path | None = None,
+    candidate_workspace: Path | None = None,
+) -> dict[str, Any]:
+    reference = require_capture(reference, "reference")
+    candidate = require_capture(candidate, "candidate")
+    errors = validate_events(reference["events"], "reference") + validate_events(
+        candidate["events"], "candidate"
+    )
+    if reference["scenario"] != candidate["scenario"]:
+        errors.append("scenario names differ")
+    normalized_reference = normalize_capture(reference, workspace=reference_workspace)
+    normalized_candidate = normalize_capture(candidate, workspace=candidate_workspace)
+    reference_text = json.dumps(normalized_reference, indent=2, sort_keys=True).splitlines()
+    candidate_text = json.dumps(normalized_candidate, indent=2, sort_keys=True).splitlines()
+    diff = list(
+        difflib.unified_diff(
+            reference_text,
+            candidate_text,
+            fromfile="reference",
+            tofile="candidate",
+            lineterm="",
+        )
+    )
+    return {
+        "artifact_type": "omp_ninfer_responses_wire_comparison",
+        "schema_version": 1,
+        "scenario": reference["scenario"],
+        "valid": not errors,
+        "equivalent": not errors and not diff,
+        "errors": errors,
+        "diff": diff,
+    }
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        return require_capture(json.loads(path.read_text(encoding="utf-8")), str(path))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CaptureError(f"{path}: {error}") from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--reference-workspace", type=Path)
+    parser.add_argument("--candidate-workspace", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        result = compare_captures(
+            load(args.reference),
+            load(args.candidate),
+            reference_workspace=args.reference_workspace,
+            candidate_workspace=args.candidate_workspace,
+        )
+    except CaptureError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(payload, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+        temporary.write_text(payload, encoding="utf-8")
+        temporary.replace(args.output)
+    return 0 if result["equivalent"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Sequence
 
 DEFAULT_GPU_ID = "NVIDIA GeForce RTX 5090"
 DEFAULT_IMAGE = "runpod/pytorch:1.1.0-cu1300-torch291-ubuntu2404"
+DEFAULT_CUDA_PACKAGES = ("cuda-compiler-13-1", "cuda-libraries-dev-13-1")
 DEFAULT_CTEST_REGEX = (
     "ninfer_(resource_manager|openai_schema|responses_schema|response_store|"
     "tool_call_parser|serve_options|request_log)_test"
@@ -192,13 +193,13 @@ def remote_script(
     source_commit: str,
     upstream_base: str,
     cuda_arch: str,
-    cuda_toolkit_package: str,
+    cuda_packages: Sequence[str],
     ctest_regex: str,
 ) -> str:
     packages = (
         "cmake git ninja-build pkg-config libavcodec-dev libavformat-dev "
         "libavutil-dev libcurl4-openssl-dev libssl-dev libswscale-dev "
-        + shlex.quote(cuda_toolkit_package)
+        + " ".join(shlex.quote(package) for package in cuda_packages)
     )
     targets = (
         "ninfer ninfer-serve ninfer_resource_manager_test ninfer_openai_schema_test "
@@ -259,7 +260,12 @@ def main() -> int:
     parser.add_argument("--cloud-type", choices=("COMMUNITY", "SECURE"), default="COMMUNITY")
     parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--cuda-arch", default="120a")
-    parser.add_argument("--cuda-toolkit-package", default="cuda-toolkit-13-1")
+    parser.add_argument(
+        "--cuda-package",
+        action="append",
+        dest="cuda_packages",
+        help="CUDA apt package; repeat as needed",
+    )
     parser.add_argument("--container-disk-gb", type=int, default=40)
     parser.add_argument("--max-hourly-price", type=float, default=0.70)
     parser.add_argument("--cleanup-deadline-minutes", type=int, default=55)
@@ -272,6 +278,9 @@ def main() -> int:
         parser.error("--container-disk-gb must be at least 20")
     if not 10 <= args.cleanup_deadline_minutes <= 180:
         parser.error("--cleanup-deadline-minutes must be between 10 and 180")
+    cuda_packages = tuple(args.cuda_packages or DEFAULT_CUDA_PACKAGES)
+    if not cuda_packages or any(not package for package in cuda_packages):
+        parser.error("at least one non-empty --cuda-package is required")
 
     install_signal_handlers()
     source = args.source.resolve()
@@ -287,6 +296,7 @@ def main() -> int:
         "cloud_type": args.cloud_type,
         "image": args.image,
         "cuda_arch": args.cuda_arch,
+        "cuda_packages": list(cuda_packages),
         "hourly_price_usd": None,
         "pod_id": None,
         "pod_deleted": False,
@@ -405,7 +415,7 @@ def main() -> int:
                 source_commit=source_commit,
                 upstream_base=upstream_base,
                 cuda_arch=args.cuda_arch,
-                cuda_toolkit_package=args.cuda_toolkit_package,
+                cuda_packages=cuda_packages,
                 ctest_regex=args.ctest_regex,
             )
             remote_result = run_command(["ssh", *ssh_options, f"root@{host}", remote])

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -197,7 +197,7 @@ def remote_script(
 ) -> str:
     packages = (
         "cmake git ninja-build pkg-config libavcodec-dev libavformat-dev "
-        "libavutil-dev libcurl4-openssl-dev libswscale-dev "
+        "libavutil-dev libcurl4-openssl-dev libssl-dev libswscale-dev "
         + shlex.quote(cuda_toolkit_package)
     )
     targets = (

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Run a clean NInfer build and focused contract tests on an ephemeral RunPod GPU."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+DEFAULT_GPU_ID = "NVIDIA GeForce RTX 5090"
+DEFAULT_IMAGE = "runpod/pytorch:1.1.0-cu1300-torch291-ubuntu2404"
+DEFAULT_CTEST_REGEX = (
+    "ninfer_(resource_manager|openai_schema|responses_schema|response_store|"
+    "tool_call_parser|serve_options|request_log)_test"
+)
+GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+TRANSIENT_RUNPOD_ERRORS = {"network_error", "rate_limited", "server_error"}
+
+
+class CiError(RuntimeError):
+    """A bounded CI lifecycle failure."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+Runner = Callable[[Sequence[str]], CommandResult]
+
+
+def run_command(command: Sequence[str], *, cwd: Path | None = None) -> CommandResult:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def require_success(result: CommandResult, step: str) -> CommandResult:
+    if result.returncode == 0:
+        return result
+    detail = (result.stderr or result.stdout).strip()
+    if len(detail) > 8_000:
+        detail = detail[-8_000:]
+    raise CiError(f"{step} failed ({result.returncode}): {detail}")
+
+
+def parse_json_output(text: str) -> Any:
+    """Parse JSON even when a CLI emitted bounded progress text first."""
+    stripped = text.strip()
+    if not stripped:
+        raise CiError("command returned no JSON")
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        decoder = json.JSONDecoder()
+        for index, character in enumerate(stripped):
+            if character not in "[{":
+                continue
+            try:
+                value, end = decoder.raw_decode(stripped[index:])
+            except json.JSONDecodeError:
+                continue
+            if not stripped[index + end :].strip():
+                return value
+    raise CiError("command output did not end in valid JSON")
+
+
+def git_text(source: Path, *arguments: str) -> str:
+    result = require_success(
+        run_command(["git", "-C", str(source), *arguments]),
+        f"git {' '.join(arguments)}",
+    )
+    return result.stdout.strip()
+
+
+def validate_source(source: Path) -> str:
+    if not source.is_dir():
+        raise CiError(f"source directory does not exist: {source}")
+    commit = git_text(source, "rev-parse", "HEAD")
+    if not GIT_SHA_PATTERN.fullmatch(commit):
+        raise CiError("source HEAD is not a full lowercase Git SHA")
+    status = git_text(source, "status", "--porcelain", "--untracked-files=all")
+    if status:
+        raise CiError("source worktree must be completely clean and committed")
+    return commit
+
+
+def read_upstream_base(source: Path, override: str | None) -> str:
+    if override is not None:
+        value = override
+    else:
+        preset_path = source / "CMakePresets.json"
+        try:
+            presets = json.loads(preset_path.read_text(encoding="utf-8"))
+            value = presets["configurePresets"][0]["cacheVariables"][
+                "NINFER_UPSTREAM_BASE_SHA"
+            ]
+        except (FileNotFoundError, KeyError, IndexError, json.JSONDecodeError) as error:
+            raise CiError(
+                "cannot resolve NINFER_UPSTREAM_BASE_SHA; pass --upstream-base-sha"
+            ) from error
+    if not GIT_SHA_PATTERN.fullmatch(value):
+        raise CiError("upstream base must be a full lowercase Git SHA")
+    ancestry = run_command(["git", "-C", str(source), "merge-base", "--is-ancestor", value, "HEAD"])
+    if ancestry.returncode != 0:
+        raise CiError("upstream base is not an ancestor of source HEAD")
+    return value
+
+
+def gpu_hourly_price(catalog: Any, gpu_id: str, cloud_type: str) -> float:
+    if not isinstance(catalog, list):
+        raise CiError("runpodctl gpu list returned an unexpected shape")
+    for gpu in catalog:
+        if not isinstance(gpu, dict):
+            continue
+        if gpu.get("gpuId") != gpu_id and gpu.get("displayName") != gpu_id:
+            continue
+        if not gpu.get("available", False):
+            raise CiError(f"requested GPU is unavailable: {gpu_id}")
+        key = "communityPricePerHr" if cloud_type == "COMMUNITY" else "securePricePerHr"
+        price = gpu.get(key)
+        if not isinstance(price, (int, float)):
+            raise CiError(f"requested GPU has no {cloud_type.lower()} hourly price")
+        return float(price)
+    raise CiError(f"requested GPU was not found: {gpu_id}")
+
+
+def extract_pod_id(result: CommandResult) -> str | None:
+    for candidate in (result.stdout, result.stderr, result.stdout + "\n" + result.stderr):
+        try:
+            value = parse_json_output(candidate)
+        except CiError:
+            value = None
+        if isinstance(value, dict) and isinstance(value.get("id"), str):
+            return value["id"]
+    match = re.search(r"\bpod ([a-z0-9]{8,})\b", result.stderr + "\n" + result.stdout)
+    return match.group(1) if match else None
+
+
+def runpod_error_code(result: CommandResult) -> str | None:
+    for candidate in (result.stdout, result.stderr):
+        try:
+            value = parse_json_output(candidate)
+        except CiError:
+            continue
+        if isinstance(value, dict) and isinstance(value.get("code"), str):
+            return value["code"]
+    return None
+
+
+def delete_pod(
+    pod_id: str,
+    *,
+    runner: Runner = run_command,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    delays = (0.0, 2.0, 5.0)
+    last: CommandResult | None = None
+    for delay in delays:
+        if delay:
+            sleep(delay)
+        last = runner(["runpodctl", "pod", "delete", pod_id])
+        if last.returncode == 0:
+            return
+        if runpod_error_code(last) not in TRANSIENT_RUNPOD_ERRORS:
+            break
+    assert last is not None
+    detail = (last.stderr or last.stdout).strip()
+    raise CiError(f"URGENT: failed to delete billing pod {pod_id}: {detail}")
+
+
+def remote_script(
+    *,
+    source_commit: str,
+    upstream_base: str,
+    cuda_arch: str,
+    cuda_toolkit_package: str,
+    ctest_regex: str,
+) -> str:
+    packages = (
+        "cmake git ninja-build pkg-config libavcodec-dev libavformat-dev "
+        "libavutil-dev libcurl4-openssl-dev libswscale-dev "
+        + shlex.quote(cuda_toolkit_package)
+    )
+    targets = (
+        "ninfer ninfer-serve ninfer_resource_manager_test ninfer_openai_schema_test "
+        "ninfer_responses_schema_test ninfer_response_store_test "
+        "ninfer_tool_call_parser_test ninfer_serve_options_test ninfer_request_log_test"
+    )
+    return f"""set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends {packages}
+export PATH=/usr/local/cuda-13.1/bin:$PATH
+rm -rf /workspace/ninfer
+mkdir -p /workspace/ninfer
+git clone -q /workspace/omp-ninfer-ci.bundle /workspace/ninfer
+cd /workspace/ninfer
+[[ $(git rev-parse HEAD) == {shlex.quote(source_commit)} ]]
+[[ -z $(git status --porcelain --untracked-files=all) ]]
+cmake -S . -B build/runpod -G Ninja \\
+  -DCMAKE_BUILD_TYPE=Release \\
+  -DCMAKE_CUDA_ARCHITECTURES={shlex.quote(cuda_arch)} \\
+  -DNINFER_BUILD_APPS=ON \\
+  -DBUILD_TESTING=ON \\
+  -DNINFER_BUILD_BENCHMARKS=OFF \\
+  -DNINFER_BUILD_PROFILE=runpod-ci \\
+  -DNINFER_UPSTREAM_BASE_SHA={shlex.quote(upstream_base)} \\
+  -DNINFER_PATCH_STACK_SHA={shlex.quote(source_commit)} \\
+  -DNINFER_SOURCE_CLEAN_VERIFIED=ON
+cmake --build build/runpod --parallel --target {targets}
+ctest --test-dir build/runpod --output-on-failure -R {shlex.quote(ctest_regex)}
+build/runpod/apps/ninfer-serve --version
+"""
+
+
+def write_receipt(path: Path | None, receipt: dict[str, Any]) -> None:
+    payload = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if path is None:
+        print(payload, end="")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(payload, encoding="utf-8")
+    temporary.replace(path)
+
+
+def install_signal_handlers() -> None:
+    def terminate(signum: int, _frame: object) -> None:
+        del _frame
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, terminate)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--upstream-base-sha")
+    parser.add_argument("--gpu-id", default=DEFAULT_GPU_ID)
+    parser.add_argument("--cloud-type", choices=("COMMUNITY", "SECURE"), default="COMMUNITY")
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--cuda-arch", default="120a")
+    parser.add_argument("--cuda-toolkit-package", default="cuda-toolkit-13-1")
+    parser.add_argument("--container-disk-gb", type=int, default=40)
+    parser.add_argument("--max-hourly-price", type=float, default=0.70)
+    parser.add_argument("--cleanup-deadline-minutes", type=int, default=55)
+    parser.add_argument("--wait-timeout", default="15m")
+    parser.add_argument("--ctest-regex", default=DEFAULT_CTEST_REGEX)
+    parser.add_argument("--receipt", type=Path)
+    args = parser.parse_args()
+
+    if args.container_disk_gb < 20:
+        parser.error("--container-disk-gb must be at least 20")
+    if not 10 <= args.cleanup_deadline_minutes <= 180:
+        parser.error("--cleanup-deadline-minutes must be between 10 and 180")
+
+    install_signal_handlers()
+    source = args.source.resolve()
+    started = dt.datetime.now(dt.UTC)
+    receipt: dict[str, Any] = {
+        "artifact_type": "omp_ninfer_runpod_ci_receipt",
+        "schema_version": 1,
+        "started_at": started.isoformat(),
+        "status": "failed",
+        "source_commit": None,
+        "upstream_base_sha": None,
+        "gpu_id": args.gpu_id,
+        "cloud_type": args.cloud_type,
+        "image": args.image,
+        "cuda_arch": args.cuda_arch,
+        "hourly_price_usd": None,
+        "pod_id": None,
+        "pod_deleted": False,
+        "failed_step": None,
+    }
+    pod_id: str | None = None
+    watchdog: subprocess.Popen[bytes] | None = None
+    failure: BaseException | None = None
+
+    try:
+        source_commit = validate_source(source)
+        upstream_base = read_upstream_base(source, args.upstream_base_sha)
+        receipt["source_commit"] = source_commit
+        receipt["upstream_base_sha"] = upstream_base
+
+        require_success(run_command(["runpodctl", "user"]), "RunPod authentication")
+        catalog_result = require_success(run_command(["runpodctl", "gpu", "list"]), "GPU catalog")
+        price = gpu_hourly_price(parse_json_output(catalog_result.stdout), args.gpu_id, args.cloud_type)
+        receipt["hourly_price_usd"] = price
+        if price > args.max_hourly_price:
+            raise CiError(
+                f"hourly price ${price:.2f} exceeds cap ${args.max_hourly_price:.2f}"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="omp-ninfer-runpod-") as temporary:
+            bundle = Path(temporary) / "omp-ninfer-ci.bundle"
+            require_success(
+                run_command(["git", "-C", str(source), "bundle", "create", str(bundle), "HEAD"]),
+                "source bundle",
+            )
+            pod_name = "omp-ninfer-ci-" + started.strftime("%Y%m%d-%H%M%S")
+            create_command = [
+                "runpodctl",
+                "pod",
+                "create",
+                "--name",
+                pod_name,
+                "--image",
+                args.image,
+                "--gpu-id",
+                args.gpu_id,
+                "--cloud-type",
+                args.cloud_type,
+                "--container-disk-in-gb",
+                str(args.container_disk_gb),
+                "--ports",
+                "22/tcp",
+                "--wait",
+                "--wait-timeout",
+                args.wait_timeout,
+            ]
+            if args.cloud_type == "COMMUNITY":
+                create_command.append("--public-ip")
+            created = run_command(create_command)
+            pod_id = extract_pod_id(created)
+            if pod_id is None:
+                require_success(created, "pod creation")
+                raise CiError("pod creation returned no pod id")
+            receipt["pod_id"] = pod_id
+            require_success(created, "pod readiness")
+
+            watchdog = subprocess.Popen(
+                [
+                    "/bin/sh",
+                    "-c",
+                    f"sleep {args.cleanup_deadline_minutes * 60}; "
+                    f"runpodctl pod delete {shlex.quote(pod_id)} >/dev/null 2>&1",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+
+            ssh_result = require_success(
+                run_command(["runpodctl", "ssh", "info", pod_id]), "SSH discovery"
+            )
+            ssh = parse_json_output(ssh_result.stdout)
+            try:
+                host = ssh["ip"]
+                port = str(ssh["port"])
+                key = ssh["ssh_key"]["path"]
+            except (KeyError, TypeError) as error:
+                raise CiError("runpodctl ssh info returned an unexpected shape") from error
+
+            ssh_options = [
+                "-i",
+                key,
+                "-p",
+                port,
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-o",
+                "ConnectTimeout=20",
+            ]
+            require_success(
+                run_command(
+                    [
+                        "scp",
+                        "-q",
+                        "-i",
+                        key,
+                        "-P",
+                        port,
+                        "-o",
+                        "StrictHostKeyChecking=accept-new",
+                        str(bundle),
+                        f"root@{host}:/workspace/omp-ninfer-ci.bundle",
+                    ]
+                ),
+                "bundle transfer",
+            )
+            remote = remote_script(
+                source_commit=source_commit,
+                upstream_base=upstream_base,
+                cuda_arch=args.cuda_arch,
+                cuda_toolkit_package=args.cuda_toolkit_package,
+                ctest_regex=args.ctest_regex,
+            )
+            remote_result = run_command(["ssh", *ssh_options, f"root@{host}", remote])
+            if remote_result.stdout:
+                print(remote_result.stdout, end="")
+            require_success(remote_result, "remote build and tests")
+            receipt["status"] = "passed"
+    except BaseException as error:  # cleanup must also run for SIGTERM/KeyboardInterrupt
+        failure = error
+        receipt["failed_step"] = type(error).__name__
+    finally:
+        if pod_id is not None:
+            try:
+                delete_pod(pod_id)
+                receipt["pod_deleted"] = True
+            except BaseException as cleanup_error:
+                failure = cleanup_error
+                receipt["failed_step"] = type(cleanup_error).__name__
+        if watchdog is not None and watchdog.poll() is None:
+            watchdog.terminate()
+        receipt["finished_at"] = dt.datetime.now(dt.UTC).isoformat()
+        write_receipt(args.receipt, receipt)
+
+    if failure is not None:
+        print(f"error: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -24,6 +24,7 @@ OCI_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 OMP_RELEASE_ID_RE = re.compile(
     r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-cross-platform-preview-(?P<preview>[1-9][0-9]*)$"
 )
+PRODUCT_RELEASE_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$")
 OMP_ASSET_DOWNLOAD_RE = re.compile(
     r"^/alphastorm/homebrew-omp/releases/download/(?P<tag>[^/]+)/(?P<name>[^/]+)$"
 )
@@ -53,6 +54,15 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ContractError(f"{path}: root must be an object")
     return value
+
+
+def resolve_product_release(root: Path, requested: str | None) -> str:
+    release = requested
+    if release is None:
+        release = load_json(root / "compatibility.json").get("product_release")
+    if not isinstance(release, str) or PRODUCT_RELEASE_RE.fullmatch(release) is None:
+        raise ContractError("product release must be a versioned release directory name")
+    return release
 
 
 def sha256_file(path: Path) -> str:
@@ -107,20 +117,48 @@ def argument_value(arguments: list[Any], flag: str) -> Any:
     return arguments[index + 1] if index + 1 < len(arguments) else None
 
 
-REQUIRED_SERVER_VALUES = {
-    "--host": "127.0.0.1",
-    "--port": "18089",
-    "--model-id": "q38-ninfer",
-    "--deployment-profile": "qwen38-5090-v0.1.0",
-    "--max-context": "131072",
-    "--kv-capacity": "auto",
-    "--prefill-chunk": "1024",
-    "--kv-dtype": "bf16",
-    "--max-concurrency": "1",
-    "--spec": "mtp",
-    "--draft-tokens": "3",
-}
+REQUIRED_TUNING_VALUES = (
+    "--kv-capacity",
+    "--prefill-chunk",
+    "--kv-dtype",
+    "--max-concurrency",
+    "--spec",
+    "--draft-tokens",
+)
 REQUIRED_SERVER_FLAGS = ("--lm-head-draft", "--vision", "--preserve-thinking")
+
+
+def validate_server_arguments(
+    profile: dict[str, Any], label: str, errors: list[str]
+) -> None:
+    transport = profile.get("transport", {})
+    model = profile.get("model", {})
+    server = profile.get("server", {})
+    provider = profile.get("omp_provider", {})
+    arguments = server.get("arguments", [])
+    if not isinstance(arguments, list) or not all(isinstance(item, str) for item in arguments):
+        require(False, f"{label}: server.arguments must be a string array", errors)
+        return
+
+    expected_values = {
+        "--host": transport.get("runtime_bind_host"),
+        "--port": str(transport.get("runtime_port")),
+        "--model-id": model.get("public_id"),
+        "--deployment-profile": server.get("deployment_profile"),
+        "--max-context": str(provider.get("context_window")),
+    }
+    for flag, expected in expected_values.items():
+        require(isinstance(expected, str) and expected not in {"", "None"},
+                f"{label}: cannot derive {flag} from structured profile fields", errors)
+        require(arguments.count(flag) == 1 and argument_value(arguments, flag) == expected,
+                f"{label}: {flag} must occur once and equal {expected}", errors)
+    for flag in REQUIRED_TUNING_VALUES:
+        value = argument_value(arguments, flag)
+        require(arguments.count(flag) == 1 and isinstance(value, str) and bool(value),
+                f"{label}: {flag} must occur once with a non-empty value", errors)
+    for flag in REQUIRED_SERVER_FLAGS:
+        require(arguments.count(flag) == 1, f"{label}: must include {flag} exactly once", errors)
+    require("--api-key" not in arguments, f"{label}: must not embed an API key", errors)
 
 
 def validate_profile_contract(
@@ -145,18 +183,10 @@ def validate_profile_contract(
             f"{label}: silent cloud fallback must be disabled", errors)
 
     server = profile.get("server", {})
-    arguments = server.get("arguments", [])
-    require(isinstance(arguments, list) and all(isinstance(item, str) for item in arguments),
-            f"{label}: server.arguments must be a string array", errors)
     require(server.get("restart_policy") == "no", f"{label}: restart_policy must be no", errors)
     require(server.get("container_network_mode") == "host",
             f"{label}: container network mode must be host", errors)
-    for flag, expected in REQUIRED_SERVER_VALUES.items():
-        require(argument_value(arguments, flag) == expected,
-                f"{label}: {flag} must equal {expected}", errors)
-    for flag in REQUIRED_SERVER_FLAGS:
-        require(flag in arguments, f"{label}: must include {flag}", errors)
-    require("--api-key" not in arguments, f"{label}: must not embed an API key", errors)
+    validate_server_arguments(profile, label, errors)
 
     omp_provider = profile.get("omp_provider", {})
     require(omp_provider.get("api") == "openai-responses",
@@ -214,14 +244,17 @@ def validate(
     root: Path,
     require_ready: bool,
     require_installable: bool = False,
+    product_release: str | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
-    manifest_path = root / "releases" / "v0.1.0-beta.1" / "manifest.json"
+    selected_release = resolve_product_release(root, product_release)
+    manifest_path = root / "releases" / selected_release / "manifest.json"
     manifest = load_json(manifest_path)
     errors: list[str] = []
 
     require(manifest.get("schema_version") == 1, "manifest schema_version must be 1", errors)
     release = manifest.get("release")
-    require(release == "v0.1.0-beta.1", "manifest release must be v0.1.0-beta.1", errors)
+    require(release == selected_release,
+            f"manifest release must match selected release {selected_release}", errors)
     status = manifest.get("status")
     require(status in {"draft", "candidate", "ready"},
             "manifest status must be draft, candidate, or ready", errors)
@@ -247,9 +280,13 @@ def validate(
 
     profile = load_json(profile_path) if profile_path.is_file() else {}
     qualification = load_json(qualification_path) if qualification_path.is_file() else {}
+    components = manifest.get("components", {})
+    omp = components.get("omp", {})
+    ninfer = components.get("ninfer", {})
+    model = components.get("model", {})
+    runtime = manifest.get("runtime_identity", {})
+    manifest_qualification = manifest.get("qualification", {})
 
-    require(profile.get("schema_version") == 1, "profile schema_version must be 1", errors)
-    require(profile.get("release") == release, "profile release must match manifest release", errors)
     expected_profile_id = product.get("primary_profile_id") if isinstance(product, dict) else None
     installation_mode = manifest.get("installation", {}).get("mode")
     require(isinstance(expected_profile_id, str) and profile.get("profile_id") == expected_profile_id,
@@ -257,47 +294,8 @@ def validate(
     require(isinstance(installation_mode, str)
             and profile.get("installation_mode") == installation_mode,
             "profile installation_mode must match manifest installation.mode", errors)
-
-    transport = profile.get("transport", {})
-    require(transport.get("client_bind_host") == "127.0.0.1",
-            "client endpoint must bind loopback", errors)
-    require(transport.get("runtime_bind_host") == "127.0.0.1",
-            "runtime endpoint must bind loopback", errors)
-    require(transport.get("client_port") == transport.get("runtime_port") == 18089,
-            "profile loopback ports must both be 18089", errors)
-    require(transport.get("silent_cloud_fallback") is False,
-            "profile must disable silent cloud fallback", errors)
-
-    server = profile.get("server", {})
-    arguments = server.get("arguments", [])
-    require(isinstance(arguments, list) and all(isinstance(item, str) for item in arguments),
-            "profile server.arguments must be a string array", errors)
-    require(server.get("restart_policy") == "no", "profile restart_policy must be no", errors)
-    require(server.get("container_network_mode") == "host",
-            "profile container network mode must be host", errors)
-    for flag, expected in REQUIRED_SERVER_VALUES.items():
-        require(argument_value(arguments, flag) == expected,
-                f"profile {flag} must equal {expected}", errors)
-    for flag in REQUIRED_SERVER_FLAGS:
-        require(flag in arguments, f"profile must include {flag}", errors)
-    require("--api-key" not in arguments, "profile must not embed an API key", errors)
-
-    omp_provider = profile.get("omp_provider", {})
-    require(omp_provider.get("api") == "openai-responses",
-            "OMP provider API must be openai-responses", errors)
-    require(omp_provider.get("base_url") == "http://127.0.0.1:18089/v1",
-            "OMP provider must use the local loopback endpoint", errors)
-    require(omp_provider.get("request_model_id") == "q38-ninfer",
-            "OMP provider request model must be q38-ninfer", errors)
-    require(omp_provider.get("ninfer_stateful_responses") is True,
-            "OMP provider must enable NInfer stateful Responses", errors)
-
-    components = manifest.get("components", {})
-    omp = components.get("omp", {})
-    ninfer = components.get("ninfer", {})
-    model = components.get("model", {})
-    runtime = manifest.get("runtime_identity", {})
-    manifest_qualification = manifest.get("qualification", {})
+    validate_profile_contract(profile, "profile", release, model,
+                              runtime.get("public_model_id"), errors)
 
     profiles_dir = root / "profiles"
     if profiles_dir.is_dir():
@@ -635,6 +633,7 @@ def validate(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--release", help="product release directory; defaults to compatibility.json")
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--require-installable", action="store_true")
     mode.add_argument("--require-ready", action="store_true")
@@ -646,6 +645,7 @@ def main() -> int:
             args.root.resolve(),
             args.require_ready,
             args.require_installable,
+            args.release,
         )
     except ContractError as error:
         errors = [str(error)]

--- a/tests/test_compare_responses_wire.py
+++ b/tests/test_compare_responses_wire.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "compare_responses_wire", ROOT / "scripts" / "compare_responses_wire.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def capture(
+    *,
+    response_id: str,
+    item_id: str,
+    call_id: str,
+    secret: str,
+    workspace: str,
+    created_at: int,
+    input_tokens: int,
+) -> dict:
+    item = {
+        "id": item_id,
+        "type": "function_call",
+        "call_id": call_id,
+        "name": "exec",
+        "arguments": json.dumps({"cmd": f"cat {workspace}/input.txt"}),
+    }
+    return {
+        "artifact_type": MODULE.ARTIFACT_TYPE,
+        "schema_version": 1,
+        "scenario": "tool-round-trip",
+        "requests": [
+            {
+                "method": "POST",
+                "path": "/v1/responses",
+                "headers": {
+                    "Authorization": "Bearer test-key",
+                    "X-NInfer-Session": secret,
+                },
+                "body": {
+                    "model": "q38-ninfer",
+                    "previous_response_id": response_id,
+                    "input": [
+                        {
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": "ok",
+                        }
+                    ],
+                },
+            }
+        ],
+        "events": [
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {"id": response_id, "created_at": created_at},
+            },
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "response_id": response_id,
+                "item": item,
+            },
+            {
+                "type": "response.output_item.done",
+                "sequence_number": 2,
+                "response_id": response_id,
+                "item": item,
+            },
+            {
+                "type": "response.completed",
+                "sequence_number": 3,
+                "response": {
+                    "id": response_id,
+                    "created_at": created_at,
+                    "output": [item],
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 7},
+                },
+            },
+        ],
+    }
+
+
+class ResponsesWireComparisonTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.reference = capture(
+            response_id="resp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            item_id="fc_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            call_id="call_cccccccccccccccccccccccccccccccc",
+            secret="1" * 64,
+            workspace="/reference/workspace",
+            created_at=100,
+            input_tokens=50,
+        )
+        self.candidate = capture(
+            response_id="resp_dddddddddddddddddddddddddddddddd",
+            item_id="fc_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            call_id="call_ffffffffffffffffffffffffffffffff",
+            secret="2" * 64,
+            workspace="/candidate/workspace",
+            created_at=999,
+            input_tokens=73,
+        )
+
+    def compare(self) -> dict:
+        return MODULE.compare_captures(
+            self.reference,
+            self.candidate,
+            reference_workspace=Path("/reference/workspace"),
+            candidate_workspace=Path("/candidate/workspace"),
+        )
+
+    def test_volatile_ids_credentials_usage_and_paths_normalize(self) -> None:
+        result = self.compare()
+        self.assertTrue(result["valid"])
+        self.assertTrue(result["equivalent"])
+        self.assertEqual(result["diff"], [])
+        serialized = json.dumps(
+            MODULE.normalize_capture(self.reference, workspace=Path("/reference/workspace"))
+        )
+        self.assertNotIn("test-key", serialized)
+        self.assertNotIn("/reference/workspace", serialized)
+        self.assertNotIn("1" * 64, serialized)
+
+    def test_semantic_request_difference_produces_readable_diff(self) -> None:
+        self.candidate["requests"][0]["body"]["input"][0]["type"] = "custom_tool_call_output"
+        result = self.compare()
+        self.assertTrue(result["valid"])
+        self.assertFalse(result["equivalent"])
+        self.assertTrue(any("custom_tool_call_output" in line for line in result["diff"]))
+
+    def test_sequence_gaps_fail_before_equivalence(self) -> None:
+        self.candidate["events"][2]["sequence_number"] = 9
+        result = self.compare()
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("contiguous" in error for error in result["errors"]))
+
+    def test_item_identity_must_survive_added_to_done(self) -> None:
+        self.candidate["events"][2]["item"] = dict(
+            self.candidate["events"][2]["item"], id="fc_11111111111111111111111111111111"
+        )
+        result = self.compare()
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("output item ids" in error for error in result["errors"]))
+
+    def test_capture_loader_rejects_wrong_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "capture.json"
+            path.write_text("{}\n", encoding="utf-8")
+            with self.assertRaisesRegex(MODULE.CaptureError, "unsupported capture identity"):
+                MODULE.load(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -32,7 +32,9 @@ class CompatibilityAuthorityTests(unittest.TestCase):
                 "linux-docker-local",
             ],
         )
-        self.assertTrue(all(profile["status"] == "preview" for profile in authority["profiles"]))
+        self.assertTrue(
+            all(profile["status"] in MODULE.STATUSES for profile in authority["profiles"])
+        )
         receipts = {profile["id"]: profile["acceptance_receipt"] for profile in authority["profiles"]}
         self.assertIsNotNone(receipts["darwin-remote-ssh"])
         self.assertIsNotNone(receipts["windows-docker-local"])

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -118,6 +118,7 @@ class RunpodCiTest(unittest.TestCase):
         )
         self.assertIn("set -euo pipefail", script)
         self.assertIn("cuda-toolkit-13-1", script)
+        self.assertIn("libssl-dev", script)
         self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=120a", script)
         self.assertIn(f"-DNINFER_PATCH_STACK_SHA={source}", script)
         self.assertIn(f"-DNINFER_UPSTREAM_BASE_SHA={upstream}", script)

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -113,11 +113,12 @@ class RunpodCiTest(unittest.TestCase):
             source_commit=source,
             upstream_base=upstream,
             cuda_arch="120a",
-            cuda_toolkit_package="cuda-toolkit-13-1",
+            cuda_packages=MODULE.DEFAULT_CUDA_PACKAGES,
             ctest_regex=MODULE.DEFAULT_CTEST_REGEX,
         )
         self.assertIn("set -euo pipefail", script)
-        self.assertIn("cuda-toolkit-13-1", script)
+        self.assertIn("cuda-compiler-13-1", script)
+        self.assertIn("cuda-libraries-dev-13-1", script)
         self.assertIn("libssl-dev", script)
         self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=120a", script)
         self.assertIn(f"-DNINFER_PATCH_STACK_SHA={source}", script)

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "run_runpod_ci", ROOT / "scripts" / "run_runpod_ci.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class RunpodCiTest(unittest.TestCase):
+    def test_parses_json_after_wait_progress(self) -> None:
+        value = MODULE.parse_json_output(
+            "waiting for ssh on pod abc12345\n"
+            '{"id":"abc12345","runtimeStatus":"running"}\n'
+        )
+        self.assertEqual(value["id"], "abc12345")
+
+    def test_catalog_price_uses_the_selected_cloud(self) -> None:
+        catalog = [
+            {
+                "available": True,
+                "displayName": "RTX 5090",
+                "gpuId": "NVIDIA GeForce RTX 5090",
+                "communityPricePerHr": 0.69,
+                "securePricePerHr": 0.99,
+            }
+        ]
+        self.assertEqual(
+            MODULE.gpu_hourly_price(catalog, "NVIDIA GeForce RTX 5090", "COMMUNITY"),
+            0.69,
+        )
+        self.assertEqual(
+            MODULE.gpu_hourly_price(catalog, "NVIDIA GeForce RTX 5090", "SECURE"),
+            0.99,
+        )
+
+    def test_delete_retries_only_transient_runpod_errors(self) -> None:
+        calls: list[list[str]] = []
+        results = iter(
+            [
+                MODULE.CommandResult(1, '{"code":"network_error"}', ""),
+                MODULE.CommandResult(0, "{}", ""),
+            ]
+        )
+
+        def runner(command: list[str]):
+            calls.append(command)
+            return next(results)
+
+        sleeps: list[float] = []
+        MODULE.delete_pod("pod12345", runner=runner, sleep=sleeps.append)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(sleeps, [2.0])
+
+        calls.clear()
+        with self.assertRaisesRegex(MODULE.CiError, "URGENT"):
+            MODULE.delete_pod(
+                "pod12345",
+                runner=lambda command: (
+                    calls.append(command)
+                    or MODULE.CommandResult(1, '{"code":"bad_request"}', "")
+                ),
+                sleep=sleeps.append,
+            )
+        self.assertEqual(len(calls), 1)
+
+    def test_source_must_be_clean_and_committed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            subprocess.run(["git", "init", "-q", str(source)], check=True)
+            subprocess.run(
+                ["git", "-C", str(source), "config", "core.fsmonitor", "false"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(source), "config", "user.name", "RunPod CI Test"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(source), "config", "user.email", "test@example.invalid"],
+                check=True,
+            )
+            tracked = source / "tracked.txt"
+            tracked.write_text("clean\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(source), "add", "tracked.txt"], check=True)
+            subprocess.run(
+                ["git", "-C", str(source), "commit", "-q", "-m", "test: seed fixture"],
+                check=True,
+            )
+            commit = MODULE.validate_source(source)
+            self.assertRegex(commit, r"^[0-9a-f]{40}$")
+
+            tracked.write_text("dirty\n", encoding="utf-8")
+            with self.assertRaisesRegex(MODULE.CiError, "completely clean"):
+                MODULE.validate_source(source)
+
+    def test_remote_script_binds_identity_and_cleanup_sensitive_tests(self) -> None:
+        source = "1" * 40
+        upstream = "2" * 40
+        script = MODULE.remote_script(
+            source_commit=source,
+            upstream_base=upstream,
+            cuda_arch="120a",
+            cuda_toolkit_package="cuda-toolkit-13-1",
+            ctest_regex=MODULE.DEFAULT_CTEST_REGEX,
+        )
+        self.assertIn("set -euo pipefail", script)
+        self.assertIn("cuda-toolkit-13-1", script)
+        self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=120a", script)
+        self.assertIn(f"-DNINFER_PATCH_STACK_SHA={source}", script)
+        self.assertIn(f"-DNINFER_UPSTREAM_BASE_SHA={upstream}", script)
+        self.assertIn("ninfer_tool_call_parser_test", script)
+        self.assertIn("ninfer_resource_manager_test", script)
+        self.assertIn("build/runpod/apps/ninfer-serve --version", script)
+
+    def test_receipt_is_atomic_and_contains_no_connection_details(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "receipt.json"
+            receipt = {
+                "artifact_type": "omp_ninfer_runpod_ci_receipt",
+                "pod_id": "pod12345",
+                "status": "passed",
+            }
+            MODULE.write_receipt(path, receipt)
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8")), receipt)
+            self.assertFalse(path.with_suffix(".json.tmp").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_release.py
+++ b/tests/test_verify_release.py
@@ -141,7 +141,29 @@ class ReleaseContractTest(unittest.TestCase):
         self.save(profile_path, profile)
 
         _, errors = VERIFY_RELEASE.validate(root, require_ready=False)
-        self.assertIn("profile container network mode must be host", errors)
+        self.assertIn("profile: container network mode must be host", errors)
+
+    def test_release_defaults_to_compatibility_authority(self) -> None:
+        self.assertEqual(
+            VERIFY_RELEASE.resolve_product_release(ROOT, None),
+            "v0.1.0-beta.1",
+        )
+        with self.assertRaisesRegex(VERIFY_RELEASE.ContractError, "versioned release"):
+            VERIFY_RELEASE.resolve_product_release(ROOT, "../v0.2.0")
+
+    def test_server_arguments_derive_hardware_specific_values(self) -> None:
+        profile = self.load(ROOT / "profiles" / "qwen38-rtx5090-windows-docker-local.json")
+        profile["omp_provider"]["context_window"] = 65536
+        arguments = profile["server"]["arguments"]
+        arguments[arguments.index("--max-context") + 1] = "65536"
+        arguments[arguments.index("--kv-dtype") + 1] = "int8"
+        errors: list[str] = []
+        VERIFY_RELEASE.validate_server_arguments(profile, "profile", errors)
+        self.assertEqual(errors, [])
+
+        arguments[arguments.index("--max-context") + 1] = "131072"
+        VERIFY_RELEASE.validate_server_arguments(profile, "profile", errors)
+        self.assertTrue(any("--max-context" in error for error in errors))
 
     def test_additional_profiles_share_the_release_contract(self) -> None:
         temporary, root = self.candidate_copy()


### PR DESCRIPTION
## Changes
- add fail-safe, cost-capped RunPod GPU CI with immutable receipts and automatic pod deletion
- generalize release verification across release directories and hardware-specific profile values
- add normalized OpenAI Responses wire differential comparison inspired by nanocodex parity techniques
- bind the scripted SM120/MTP3 profiling workflow to NInfer mainline and remove stale branch references

## Verification
- `python3.11 -m unittest discover -s tests` (46 tests)
- `python3.11 scripts/verify_release.py --require-ready`
- `python3.11 scripts/render_compatibility.py --check`
- RunPod RTX 5090 receipts passed for NInfer commits `8af16b0b` and `7c1c1936`, with pods deleted

This PR changes tooling and documentation only; it does not advance a product release or support claim.