### PR TITLE
test(ci): add checkpoint contract verification

### DIFF
--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -24,6 +24,18 @@ DEFAULT_CTEST_REGEX = (
     "ninfer_(checkpoint_io_contract|resource_manager|openai_schema|responses_schema|response_store|"
     "tool_call_parser|serve_options|request_log)_test"
 )
+DEFAULT_BUILD_TARGETS = (
+    "ninfer",
+    "ninfer-serve",
+    "ninfer_checkpoint_io_contract_test",
+    "ninfer_resource_manager_test",
+    "ninfer_openai_schema_test",
+    "ninfer_responses_schema_test",
+    "ninfer_response_store_test",
+    "ninfer_tool_call_parser_test",
+    "ninfer_serve_options_test",
+    "ninfer_request_log_test",
+)
 GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 TRANSIENT_RUNPOD_ERRORS = {"network_error", "rate_limited", "server_error"}
 
@@ -194,6 +206,7 @@ def remote_script(
     upstream_base: str,
     cuda_arch: str,
     cuda_packages: Sequence[str],
+    build_targets: Sequence[str],
     ctest_regex: str,
 ) -> str:
     packages = (
@@ -201,12 +214,7 @@ def remote_script(
         "libavutil-dev libcurl4-openssl-dev libssl-dev libswscale-dev "
         + " ".join(shlex.quote(package) for package in cuda_packages)
     )
-    targets = (
-        "ninfer ninfer-serve ninfer_checkpoint_io_contract_test "
-        "ninfer_resource_manager_test ninfer_openai_schema_test "
-        "ninfer_responses_schema_test ninfer_response_store_test "
-        "ninfer_tool_call_parser_test ninfer_serve_options_test ninfer_request_log_test"
-    )
+    targets = " ".join(shlex.quote(target) for target in build_targets)
     return f"""set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -267,6 +275,12 @@ def main() -> int:
         dest="cuda_packages",
         help="CUDA apt package; repeat as needed",
     )
+    parser.add_argument(
+        "--build-target",
+        action="append",
+        dest="build_targets",
+        help="CMake target; repeat to replace the default target set",
+    )
     parser.add_argument("--container-disk-gb", type=int, default=40)
     parser.add_argument("--max-hourly-price", type=float, default=0.70)
     parser.add_argument("--cleanup-deadline-minutes", type=int, default=55)
@@ -282,6 +296,9 @@ def main() -> int:
     cuda_packages = tuple(args.cuda_packages or DEFAULT_CUDA_PACKAGES)
     if not cuda_packages or any(not package for package in cuda_packages):
         parser.error("at least one non-empty --cuda-package is required")
+    build_targets = tuple(args.build_targets or DEFAULT_BUILD_TARGETS)
+    if not build_targets or any(not target for target in build_targets):
+        parser.error("at least one non-empty --build-target is required")
 
     install_signal_handlers()
     source = args.source.resolve()
@@ -298,6 +315,7 @@ def main() -> int:
         "image": args.image,
         "cuda_arch": args.cuda_arch,
         "cuda_packages": list(cuda_packages),
+        "build_targets": list(build_targets),
         "hourly_price_usd": None,
         "pod_id": None,
         "pod_deleted": False,
@@ -417,6 +435,7 @@ def main() -> int:
                 upstream_base=upstream_base,
                 cuda_arch=args.cuda_arch,
                 cuda_packages=cuda_packages,
+                build_targets=build_targets,
                 ctest_regex=args.ctest_regex,
             )
             remote_result = run_command(["ssh", *ssh_options, f"root@{host}", remote])

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -270,6 +270,7 @@ def main() -> int:
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--upstream-base-sha")
     parser.add_argument("--gpu-id", default=DEFAULT_GPU_ID)
+    parser.add_argument("--data-center-ids")
     parser.add_argument("--cloud-type", choices=("COMMUNITY", "SECURE"), default="COMMUNITY")
     parser.add_argument("--image", default=DEFAULT_IMAGE)
     parser.add_argument("--cuda-arch", default="120a")
@@ -321,6 +322,7 @@ def main() -> int:
         "cuda_packages": list(cuda_packages),
         "build_targets": list(build_targets),
         "hourly_price_usd": None,
+        "data_center_ids": args.data_center_ids,
         "pod_id": None,
         "pod_deleted": False,
         "failed_step": None,
@@ -373,6 +375,8 @@ def main() -> int:
             ]
             if args.cloud_type == "COMMUNITY":
                 create_command.append("--public-ip")
+            if args.data_center_ids:
+                create_command.extend(["--data-center-ids", args.data_center_ids])
             created = run_command(create_command)
             pod_id = extract_pod_id(created)
             if pod_id is None:

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -19,7 +19,11 @@ from typing import Any, Callable, Sequence
 
 DEFAULT_GPU_ID = "NVIDIA GeForce RTX 5090"
 DEFAULT_IMAGE = "runpod/pytorch:1.1.0-cu1300-torch291-ubuntu2404"
-DEFAULT_CUDA_PACKAGES = ("cuda-compiler-13-1", "cuda-libraries-dev-13-1")
+DEFAULT_CUDA_PACKAGES = (
+    "cuda-compiler-13-1",
+    "cuda-libraries-dev-13-1",
+    "cuda-nvtx-13-1",
+)
 DEFAULT_CTEST_REGEX = (
     "ninfer_(checkpoint_io_contract|resource_manager|openai_schema|responses_schema|response_store|"
     "tool_call_parser|serve_options|request_log)_test"

--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -21,7 +21,7 @@ DEFAULT_GPU_ID = "NVIDIA GeForce RTX 5090"
 DEFAULT_IMAGE = "runpod/pytorch:1.1.0-cu1300-torch291-ubuntu2404"
 DEFAULT_CUDA_PACKAGES = ("cuda-compiler-13-1", "cuda-libraries-dev-13-1")
 DEFAULT_CTEST_REGEX = (
-    "ninfer_(resource_manager|openai_schema|responses_schema|response_store|"
+    "ninfer_(checkpoint_io_contract|resource_manager|openai_schema|responses_schema|response_store|"
     "tool_call_parser|serve_options|request_log)_test"
 )
 GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -202,7 +202,8 @@ def remote_script(
         + " ".join(shlex.quote(package) for package in cuda_packages)
     )
     targets = (
-        "ninfer ninfer-serve ninfer_resource_manager_test ninfer_openai_schema_test "
+        "ninfer ninfer-serve ninfer_checkpoint_io_contract_test "
+        "ninfer_resource_manager_test ninfer_openai_schema_test "
         "ninfer_responses_schema_test ninfer_response_store_test "
         "ninfer_tool_call_parser_test ninfer_serve_options_test ninfer_request_log_test"
     )

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -124,6 +124,7 @@ class RunpodCiTest(unittest.TestCase):
         self.assertIn(f"-DNINFER_PATCH_STACK_SHA={source}", script)
         self.assertIn(f"-DNINFER_UPSTREAM_BASE_SHA={upstream}", script)
         self.assertIn("ninfer_tool_call_parser_test", script)
+        self.assertIn("ninfer_checkpoint_io_contract_test", script)
         self.assertIn("ninfer_resource_manager_test", script)
         self.assertIn("build/runpod/apps/ninfer-serve --version", script)
 

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -114,6 +114,7 @@ class RunpodCiTest(unittest.TestCase):
             upstream_base=upstream,
             cuda_arch="120a",
             cuda_packages=MODULE.DEFAULT_CUDA_PACKAGES,
+            build_targets=MODULE.DEFAULT_BUILD_TARGETS,
             ctest_regex=MODULE.DEFAULT_CTEST_REGEX,
         )
         self.assertIn("set -euo pipefail", script)
@@ -127,6 +128,20 @@ class RunpodCiTest(unittest.TestCase):
         self.assertIn("ninfer_checkpoint_io_contract_test", script)
         self.assertIn("ninfer_resource_manager_test", script)
         self.assertIn("build/runpod/apps/ninfer-serve --version", script)
+
+    def test_remote_script_uses_the_requested_build_targets(self) -> None:
+        script = MODULE.remote_script(
+            source_commit="1" * 40,
+            upstream_base="2" * 40,
+            cuda_arch="86",
+            cuda_packages=MODULE.DEFAULT_CUDA_PACKAGES,
+            build_targets=("ninfer-serve", "ninfer_session_checkpoint_store_test"),
+            ctest_regex="ninfer_session_checkpoint_store_test",
+        )
+        self.assertIn(
+            "--target ninfer-serve ninfer_session_checkpoint_store_test", script
+        )
+        self.assertNotIn("ninfer_checkpoint_io_contract_test", script)
 
     def test_receipt_is_atomic_and_contains_no_connection_details(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -120,6 +120,7 @@ class RunpodCiTest(unittest.TestCase):
         self.assertIn("set -euo pipefail", script)
         self.assertIn("cuda-compiler-13-1", script)
         self.assertIn("cuda-libraries-dev-13-1", script)
+        self.assertIn("cuda-nvtx-13-1", script)
         self.assertIn("libssl-dev", script)
         self.assertIn("-DCMAKE_CUDA_ARCHITECTURES=120a", script)
         self.assertIn(f"-DNINFER_PATCH_STACK_SHA={source}", script)


### PR DESCRIPTION
Add the dependency-light checkpoint I/O contract target to the bounded RunPod native GPU build and focused CTest gate.

Verification:
- `python3.11 -m unittest discover -s tests` (46 tests)
- `python3.11 scripts/verify_release.py --require-ready`
- diff check clean