### PR TITLE
fix(ci): retry transient bundle transfers

### DIFF
--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -79,6 +79,24 @@ def require_success(result: CommandResult, step: str) -> CommandResult:
     raise CiError(f"{step} failed ({result.returncode}): {detail}")
 
 
+def run_with_retries(
+    command: Sequence[str],
+    step: str,
+    *,
+    runner: Runner = run_command,
+    sleep: Callable[[float], None] = time.sleep,
+) -> CommandResult:
+    last: CommandResult | None = None
+    for delay in (0.0, 2.0, 5.0):
+        if delay:
+            sleep(delay)
+        last = runner(command)
+        if last.returncode == 0:
+            return last
+    assert last is not None
+    return require_success(last, step)
+
+
 def parse_json_output(text: str) -> Any:
     """Parse JSON even when a CLI emitted bounded progress text first."""
     stripped = text.strip()
@@ -421,21 +439,19 @@ def main() -> int:
                 "-o",
                 "ConnectTimeout=20",
             ]
-            require_success(
-                run_command(
-                    [
-                        "scp",
-                        "-q",
-                        "-i",
-                        key,
-                        "-P",
-                        port,
-                        "-o",
-                        "StrictHostKeyChecking=accept-new",
-                        str(bundle),
-                        f"root@{host}:/workspace/omp-ninfer-ci.bundle",
-                    ]
-                ),
+            run_with_retries(
+                [
+                    "scp",
+                    "-q",
+                    "-i",
+                    key,
+                    "-P",
+                    port,
+                    "-o",
+                    "StrictHostKeyChecking=accept-new",
+                    str(bundle),
+                    f"root@{host}:/workspace/omp-ninfer-ci.bundle",
+                ],
                 "bundle transfer",
             )
             remote = remote_script(

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -76,6 +76,26 @@ class RunpodCiTest(unittest.TestCase):
             )
         self.assertEqual(len(calls), 1)
 
+    def test_command_retry_recovers_a_transient_scp_close(self) -> None:
+        results = iter(
+            [
+                MODULE.CommandResult(255, "", "scp: Connection closed"),
+                MODULE.CommandResult(255, "", "scp: Connection closed"),
+                MODULE.CommandResult(0, "", ""),
+            ]
+        )
+        calls: list[list[str]] = []
+        sleeps: list[float] = []
+        result = MODULE.run_with_retries(
+            ["scp", "bundle", "host:/workspace/bundle"],
+            "bundle transfer",
+            runner=lambda command: calls.append(list(command)) or next(results),
+            sleep=sleeps.append,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(sleeps, [2.0, 5.0])
+
     def test_source_must_be_clean_and_committed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             source = Path(temporary)


### PR DESCRIPTION
Retry the idempotent SCP bundle upload with bounded 0/2/5-second attempts. This closes the observed post-readiness `scp: Connection closed` failure without retrying pod creation, builds, tests, or cleanup semantics.

Verification: 48 product tests pass; LSP diagnostics clean; diff check clean.