### PR TITLE
feat(release): accept qualified OMP beta identities

### DIFF
--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -22,7 +22,8 @@ SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 OCI_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 OMP_RELEASE_ID_RE = re.compile(
-    r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-cross-platform-preview-(?P<preview>[1-9][0-9]*)$"
+    r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-cross-platform-"
+    r"(?P<channel>preview|beta)-(?P<sequence>[1-9][0-9]*)$"
 )
 PRODUCT_RELEASE_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$")
 OMP_ASSET_DOWNLOAD_RE = re.compile(
@@ -405,7 +406,8 @@ def validate(
         else None
     )
     require(omp_release_match is not None,
-            "components.omp.release_id must be a cross-platform preview identity", errors)
+            "components.omp.release_id must be a cross-platform preview or beta identity",
+            errors)
     if omp_release_match is not None:
         omp_version = omp_release_match.group("version")
         require(omp.get("upstream_tag") == f"v{omp_version}",

--- a/tests/test_verify_release.py
+++ b/tests/test_verify_release.py
@@ -18,6 +18,21 @@ SPEC.loader.exec_module(VERIFY_RELEASE)
 
 
 class ReleaseContractTest(unittest.TestCase):
+    def test_omp_component_identity_accepts_preview_and_beta_only(self) -> None:
+        self.assertIsNotNone(
+            VERIFY_RELEASE.OMP_RELEASE_ID_RE.fullmatch(
+                "18.0.9-cross-platform-beta-1"
+            )
+        )
+        self.assertIsNotNone(
+            VERIFY_RELEASE.OMP_RELEASE_ID_RE.fullmatch(
+                "18.0.9-cross-platform-preview-5"
+            )
+        )
+        self.assertIsNone(
+            VERIFY_RELEASE.OMP_RELEASE_ID_RE.fullmatch("18.0.9-cross-platform-stable-1")
+        )
+
     def candidate_copy(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
         temporary = tempfile.TemporaryDirectory()
         root = Path(temporary.name)


### PR DESCRIPTION
Allow manifest-bound OMP component releases to use either the existing `cross-platform-preview-N` identity or the now-qualified `cross-platform-beta-N` identity. Stable/GA vocabulary remains rejected.

Verification: 49 tests, ready v0.1 manifest verification, LSP diagnostics, and diff check pass.