### PR TITLE
feat(ci): collect verified RunPod release artifacts

### DIFF
--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import re
 import shlex
@@ -230,6 +231,8 @@ def remote_script(
     cuda_packages: Sequence[str],
     build_targets: Sequence[str],
     ctest_regex: str,
+    build_profile: str = "runpod-ci",
+    release_version: str | None = None,
 ) -> str:
     packages = (
         "cmake git ninja-build pkg-config libavcodec-dev libavformat-dev "
@@ -237,6 +240,21 @@ def remote_script(
         + " ".join(shlex.quote(package) for package in cuda_packages)
     )
     targets = " ".join(shlex.quote(target) for target in build_targets)
+    package = ""
+    if release_version is not None:
+        package = f"""
+rm -rf /workspace/ninfer-release
+python3 tools/release/package.py \
+  --source . \
+  --ninfer build/runpod/apps/ninfer \
+  --ninfer-serve build/runpod/apps/ninfer-serve \
+  --output-dir /workspace/ninfer-release \
+  --release-version {shlex.quote(release_version)} \
+  --platform linux-x86_64-cuda13.1 \
+  --upstream-base-sha {shlex.quote(upstream_base)} \
+  --release-head-sha {shlex.quote(source_commit)} \
+  --build-profile {shlex.quote(build_profile)}
+"""
     return f"""set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -254,14 +272,50 @@ cmake -S . -B build/runpod -G Ninja \\
   -DNINFER_BUILD_APPS=ON \\
   -DBUILD_TESTING=ON \\
   -DNINFER_BUILD_BENCHMARKS=OFF \\
-  -DNINFER_BUILD_PROFILE=runpod-ci \\
+  -DNINFER_BUILD_PROFILE={shlex.quote(build_profile)} \\
   -DNINFER_UPSTREAM_BASE_SHA={shlex.quote(upstream_base)} \\
-  -DNINFER_PATCH_STACK_SHA={shlex.quote(source_commit)} \\
-  -DNINFER_SOURCE_CLEAN_VERIFIED=ON
+  -DNINFER_PATCH_STACK_SHA={shlex.quote(source_commit)}
 cmake --build build/runpod --parallel --target {targets}
 ctest --test-dir build/runpod --output-on-failure -R {shlex.quote(ctest_regex)}
 build/runpod/apps/ninfer-serve --version
+{package}
 """
+
+
+def verify_release_artifacts(path: Path) -> list[dict[str, Any]]:
+    files = sorted(item for item in path.iterdir() if item.is_file())
+    if len(files) != 4:
+        raise CiError(
+            f"release artifact directory contains {len(files)} files, expected 4"
+        )
+    checksum_files = [item for item in files if item.name.endswith(".SHA256SUMS")]
+    if len(checksum_files) != 1:
+        raise CiError("release artifact directory has no unique checksum manifest")
+    checksum_file = checksum_files[0]
+    expected: dict[str, str] = {}
+    for line in checksum_file.read_text(encoding="ascii").splitlines():
+        digest, separator, name = line.partition("  ")
+        if (
+            not separator
+            or not re.fullmatch(r"[0-9a-f]{64}", digest)
+            or Path(name).name != name
+            or name in expected
+        ):
+            raise CiError("release checksum manifest is malformed")
+        expected[name] = digest
+    payload_names = {item.name for item in files if item != checksum_file}
+    if len(expected) != 3 or set(expected) != payload_names:
+        raise CiError("release checksum manifest does not bind the complete artifact set")
+
+    result: list[dict[str, Any]] = []
+    for item in files:
+        digest = hashlib.sha256(item.read_bytes()).hexdigest()
+        if item != checksum_file and expected[item.name] != digest:
+            raise CiError(f"release artifact digest mismatch: {item.name}")
+        result.append(
+            {"name": item.name, "bytes": item.stat().st_size, "sha256": digest}
+        )
+    return result
 
 
 def write_receipt(path: Path | None, receipt: dict[str, Any]) -> None:
@@ -309,6 +363,9 @@ def main() -> int:
     parser.add_argument("--cleanup-deadline-minutes", type=int, default=55)
     parser.add_argument("--wait-timeout", default="15m")
     parser.add_argument("--ctest-regex", default=DEFAULT_CTEST_REGEX)
+    parser.add_argument("--build-profile", default="runpod-ci")
+    parser.add_argument("--release-version")
+    parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--receipt", type=Path)
     args = parser.parse_args()
 
@@ -322,6 +379,10 @@ def main() -> int:
     build_targets = tuple(args.build_targets or DEFAULT_BUILD_TARGETS)
     if not build_targets or any(not target for target in build_targets):
         parser.error("at least one non-empty --build-target is required")
+    if bool(args.release_version) != bool(args.artifact_dir):
+        parser.error("--release-version and --artifact-dir must be supplied together")
+    if args.artifact_dir is not None and args.artifact_dir.exists():
+        parser.error("--artifact-dir must not already exist")
 
     install_signal_handlers()
     source = args.source.resolve()
@@ -339,6 +400,9 @@ def main() -> int:
         "cuda_arch": args.cuda_arch,
         "cuda_packages": list(cuda_packages),
         "build_targets": list(build_targets),
+        "build_profile": args.build_profile,
+        "release_version": args.release_version,
+        "release_artifacts": [],
         "hourly_price_usd": None,
         "data_center_ids": args.data_center_ids,
         "pod_id": None,
@@ -461,11 +525,37 @@ def main() -> int:
                 cuda_packages=cuda_packages,
                 build_targets=build_targets,
                 ctest_regex=args.ctest_regex,
+                build_profile=args.build_profile,
+                release_version=args.release_version,
             )
             remote_result = run_command(["ssh", *ssh_options, f"root@{host}", remote])
             if remote_result.stdout:
                 print(remote_result.stdout, end="")
             require_success(remote_result, "remote build and tests")
+            if args.artifact_dir is not None:
+                artifact_dir = args.artifact_dir.resolve()
+                artifact_dir.parent.mkdir(parents=True, exist_ok=True)
+                artifact_staging = Path(temporary) / "downloaded-release"
+                run_with_retries(
+                    [
+                        "scp",
+                        "-q",
+                        "-r",
+                        "-i",
+                        key,
+                        "-P",
+                        port,
+                        "-o",
+                        "StrictHostKeyChecking=accept-new",
+                        f"root@{host}:/workspace/ninfer-release",
+                        str(artifact_staging),
+                    ],
+                    "release artifact transfer",
+                )
+                receipt["release_artifacts"] = verify_release_artifacts(artifact_staging)
+                if artifact_dir.exists():
+                    raise CiError("release artifact destination appeared during transfer")
+                artifact_staging.replace(artifact_dir)
             receipt["status"] = "passed"
     except BaseException as error:  # cleanup must also run for SIGTERM/KeyboardInterrupt
         failure = error

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import subprocess
 import sys
@@ -163,6 +164,46 @@ class RunpodCiTest(unittest.TestCase):
             "--target ninfer-serve ninfer_session_checkpoint_store_test", script
         )
         self.assertNotIn("ninfer_checkpoint_io_contract_test", script)
+
+    def test_remote_script_packages_exact_release_identity(self) -> None:
+        script = MODULE.remote_script(
+            source_commit="1" * 40,
+            upstream_base="2" * 40,
+            cuda_arch="120a",
+            cuda_packages=MODULE.DEFAULT_CUDA_PACKAGES,
+            build_targets=MODULE.DEFAULT_BUILD_TARGETS,
+            ctest_regex=MODULE.DEFAULT_CTEST_REGEX,
+            build_profile="omp-v0.2.0-rtx5090",
+            release_version="v0.2.0",
+        )
+        self.assertIn("-DNINFER_BUILD_PROFILE=omp-v0.2.0-rtx5090", script)
+        self.assertIn("tools/release/package.py", script)
+        self.assertIn("--release-version v0.2.0", script)
+        self.assertIn("--release-head-sha " + "1" * 40, script)
+        self.assertNotIn("NINFER_SOURCE_CLEAN_VERIFIED", script)
+
+    def test_release_artifact_verifier_binds_complete_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            payloads = {
+                "ninfer.tar.gz": b"binary",
+                "ninfer-source.tar.gz": b"source",
+                "ninfer.spdx.json": b"{}",
+            }
+            for name, content in payloads.items():
+                (root / name).write_bytes(content)
+            (root / "ninfer.SHA256SUMS").write_text(
+                "".join(
+                    f"{hashlib.sha256(content).hexdigest()}  {name}\n"
+                    for name, content in payloads.items()
+                ),
+                encoding="ascii",
+            )
+            artifacts = MODULE.verify_release_artifacts(root)
+            self.assertEqual({item["name"] for item in artifacts}, {p.name for p in root.iterdir()})
+            (root / "ninfer.tar.gz").write_bytes(b"tampered")
+            with self.assertRaisesRegex(MODULE.CiError, "digest mismatch"):
+                MODULE.verify_release_artifacts(root)
 
     def test_receipt_is_atomic_and_contains_no_connection_details(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Extend the bounded RunPod lifecycle to build an exact release profile, run NInfer's deterministic packager, download the complete four-file artifact set before pod deletion, and independently verify every payload against the package checksum manifest.

The local artifact destination must not exist, transfer remains bounded/retried, and billing cleanup still runs on every error or signal. The default CI-only path is unchanged.

Verification: 51 product tests and Python LSP diagnostics pass; artifact tamper/incomplete-set regressions included.