### PR TITLE
fix(ci): honor packager artifact cardinality

### DIFF
--- a/scripts/run_runpod_ci.py
+++ b/scripts/run_runpod_ci.py
@@ -284,9 +284,9 @@ build/runpod/apps/ninfer-serve --version
 
 def verify_release_artifacts(path: Path) -> list[dict[str, Any]]:
     files = sorted(item for item in path.iterdir() if item.is_file())
-    if len(files) != 4:
+    if len(files) < 3:
         raise CiError(
-            f"release artifact directory contains {len(files)} files, expected 4"
+            f"release artifact directory contains {len(files)} files, expected at least 3"
         )
     checksum_files = [item for item in files if item.name.endswith(".SHA256SUMS")]
     if len(checksum_files) != 1:
@@ -304,7 +304,7 @@ def verify_release_artifacts(path: Path) -> list[dict[str, Any]]:
             raise CiError("release checksum manifest is malformed")
         expected[name] = digest
     payload_names = {item.name for item in files if item != checksum_file}
-    if len(expected) != 3 or set(expected) != payload_names:
+    if len(expected) < 2 or set(expected) != payload_names:
         raise CiError("release checksum manifest does not bind the complete artifact set")
 
     result: list[dict[str, Any]] = []

--- a/tests/test_run_runpod_ci.py
+++ b/tests/test_run_runpod_ci.py
@@ -187,7 +187,6 @@ class RunpodCiTest(unittest.TestCase):
             root = Path(temporary)
             payloads = {
                 "ninfer.tar.gz": b"binary",
-                "ninfer-source.tar.gz": b"source",
                 "ninfer.spdx.json": b"{}",
             }
             for name, content in payloads.items():


### PR DESCRIPTION
Verify the packager-defined complete artifact set rather than assuming a source archive exists. Current mainline NInfer emits binary archive, SPDX SBOM, and one checksum manifest binding both payloads; future complete sets remain accepted only when every non-checksum file is bound.

Verification: 51 tests and LSP diagnostics pass.