### PR TITLE
fix(launcher): fail fast on WSL loopback drift with named diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Launcher fail-fast diagnosis `wsl-mirrored-loopback-unavailable` when the runtime logs a
+  loopback listener that the invoking namespace cannot reach, with troubleshooting entries for
+  the WSL loopback-drift signature and the non-interactive-SSH Docker credential-helper failure
+  ([#15](https://github.com/alphastorm/omp-ninfer/issues/15)).
+- Test guards binding the published warm-vs-cold follow-up numbers to their committed receipt and
+  covering the launcher's drift preflight.
 - Real-session README demo (GIF, MP4, poster) recorded against the exact released v0.2.0-beta.1
   RTX 5090 runtime, with provenance notes and a launch-copy kit under `docs/media/`.
 - Labeled maintainer warm-vs-cold follow-up-turn latency measurement on the released runtime.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -75,6 +75,37 @@ Common first failures are insufficient GPU memory, the NVIDIA runtime not being 
 mount/permission errors, or an identity mismatch. Do not restart unchanged input. Correct the named
 cause, stop the owned container, then start once.
 
+## The server listens but loopback is unreachable
+
+The launcher exits with `error: wsl-mirrored-loopback-unavailable` when the container logs
+`listening on http://127.0.0.1:18089` while the port stays unreachable from the invoking
+namespace. On Windows 11 + Docker Desktop WSL2 hosts this is WSL networking drift (for example
+after a WSL or Docker Desktop update): `.wslconfig` may still declare `networkingMode=mirrored`
+while the live VM no longer shares loopback, so a host-network container bind never surfaces on
+Windows or Ubuntu loopback.
+
+1. From Windows run `wsl --shutdown`, start Docker Desktop, and wait for the engine.
+2. Rerun the launcher once. Do not change ports or bind addresses as a workaround; that would
+   diverge from the qualified profile identity.
+
+First observed post-release on the maintainer qualification host
+([#15](https://github.com/alphastorm/omp-ninfer/issues/15)).
+
+## Docker credential helper fails over non-interactive SSH
+
+`docker pull` can fail with `error getting credentials … A specified logon session does not
+exist` when Docker Desktop's Windows credential helper runs inside a non-interactive SSH
+session — even for anonymous public pulls. Point `DOCKER_CONFIG` at an empty configuration for
+the launcher invocation:
+
+```sh
+DOCKER_CONFIG=$(mktemp -d)
+printf '{}\n' > "$DOCKER_CONFIG/config.json"
+export DOCKER_CONFIG
+```
+
+This bypasses only credential lookup; digest pinning and hash verification are unchanged.
+
 ## Authenticated status returns `401`
 
 The Mac and inference host must contain the same single-line key. Check file existence and mode

--- a/examples/manual-tunnel/start-ninfer.sh
+++ b/examples/manual-tunnel/start-ninfer.sh
@@ -206,6 +206,55 @@ CONTAINER_ID=$(
 )
 printf 'started %s (%s)\n' "$CONTAINER" "$CONTAINER_ID"
 
+# Fail fast on the WSL mirrored-loopback drift signature: the server logs that it is
+# listening on host loopback, but the port is unreachable from this namespace
+# (docs/TROUBLESHOOTING.md, "The server listens but loopback is unreachable").
+probe_loopback() {
+  python3 - <<'PY'
+import socket
+import sys
+
+probe = socket.socket()
+probe.settimeout(3)
+try:
+    probe.connect(("127.0.0.1", 18089))
+except OSError:
+    sys.exit(1)
+finally:
+    probe.close()
+PY
+}
+
+LISTENING_PATTERN='listening on http://127.0.0.1:18089'
+LISTENING_GRACE=${NINFER_LOOPBACK_GRACE:-15}
+PREFLIGHT_DEADLINE=$((SECONDS + 900))
+LISTENING_SINCE=
+LOOPBACK_REACHABLE=false
+while ((SECONDS < PREFLIGHT_DEADLINE)); do
+  if probe_loopback; then
+    LOOPBACK_REACHABLE=true
+    break
+  fi
+  if [[ -z "$LISTENING_SINCE" ]]; then
+    if docker logs "$CONTAINER" 2>&1 | grep -qF "$LISTENING_PATTERN"; then
+      LISTENING_SINCE=$SECONDS
+    fi
+  elif ((SECONDS - LISTENING_SINCE >= LISTENING_GRACE)); then
+    printf 'error: wsl-mirrored-loopback-unavailable\n' >&2
+    printf 'NInfer logs "%s", but host loopback cannot reach the port.\n' "$LISTENING_PATTERN" >&2
+    printf 'The WSL/Docker Desktop loopback path has drifted on this host.\n' >&2
+    printf 'Recovery: from Windows run `wsl --shutdown`, start Docker Desktop, then rerun this launcher.\n' >&2
+    printf 'See docs/TROUBLESHOOTING.md; the container stays up for `docker logs %s`.\n' "$CONTAINER" >&2
+    exit 1
+  fi
+  sleep 5
+done
+if [[ "$LOOPBACK_REACHABLE" != true ]]; then
+  printf 'error: NInfer did not become ready within 900 seconds: loopback connection never succeeded\n' >&2
+  printf 'Inspect `docker logs %s`; the container is left in place for diagnosis.\n' "$CONTAINER" >&2
+  exit 1
+fi
+
 python3 - \
   "$API_KEY_FILE" \
   "$EXPECTED_UPSTREAM_COMMIT" \

--- a/tests/test_manual_tunnel_scripts.py
+++ b/tests/test_manual_tunnel_scripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socket
 import stat
 import subprocess
 import tempfile
@@ -206,6 +207,109 @@ class ManualTunnelScriptsTest(unittest.TestCase):
             network_index = arguments.index("--network")
             self.assertEqual(arguments[network_index + 1], "host")
             self.assertNotIn("--publish", arguments)
+
+    @staticmethod
+    def write_common_fakes(fake_bin: Path) -> None:
+        (fake_bin / "nvidia-smi").write_text(
+            "#!/bin/sh\nprintf 'NVIDIA GeForce RTX 5090, 32607 MiB, 12.0\\n'\n",
+            encoding="utf-8",
+        )
+        (fake_bin / "chmod").write_text(
+            "#!/bin/sh\n"
+            "if [ \"$2\" = -- ]; then exec /bin/chmod \"$1\" \"$3\"; fi\n"
+            "exec /bin/chmod \"$@\"\n",
+            encoding="utf-8",
+        )
+        (fake_bin / "sha256sum").write_text(
+            "#!/bin/sh\n[ \"$1\" = -- ] && shift\n"
+            "printf '%s  %s\\n' \"$EXPECTED_MODEL_SHA256\" \"$1\"\n",
+            encoding="utf-8",
+        )
+        for name in ("chmod", "docker", "nvidia-smi", "sha256sum"):
+            path = fake_bin / name
+            path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def test_start_names_loopback_drift_when_listening_is_unreachable(self) -> None:
+        probe = socket.socket()
+        probe.settimeout(0.5)
+        try:
+            probe.connect(("127.0.0.1", 18089))
+        except OSError:
+            pass
+        else:
+            self.skipTest("local port 18089 is in use; drift preflight cannot be exercised")
+        finally:
+            probe.close()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.copy_contract_tree(root)
+
+            manifest_path = root / "releases" / "v0.2.0-beta.1" / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+            model = root / "model.ninfer"
+            with model.open("wb") as model_file:
+                model_file.truncate(manifest["components"]["model"]["artifact_bytes"])
+
+            key = root / "api-key"
+            key.write_text("test-key\n", encoding="utf-8")
+            key.chmod(0o600)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            (fake_bin / "docker").write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1:$2\" = \"container:inspect\" ]; then exit 1; fi\n"
+                "if [ \"$1\" = pull ]; then exit 0; fi\n"
+                "if [ \"$1\" = logs ]; then\n"
+                "  printf 'listening on http://127.0.0.1:18089\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = run ]; then\n"
+                "  for argument in \"$@\"; do\n"
+                "    if [ \"$argument\" = --entrypoint ]; then\n"
+                "      printf '%s  /usr/local/bin/ninfer-serve\\n' "
+                "\"$EXPECTED_BINARY_SHA256\"\n"
+                "      exit 0\n"
+                "    fi\n"
+                "  done\n"
+                "  printf 'fake-container-id\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 2\n",
+                encoding="utf-8",
+            )
+            self.write_common_fakes(fake_bin)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            environment["EXPECTED_BINARY_SHA256"] = manifest["components"]["ninfer"][
+                "server_binary_sha256"
+            ]
+            environment["EXPECTED_MODEL_SHA256"] = manifest["components"]["model"][
+                "artifact_sha256"
+            ]
+            environment["NINFER_LOOPBACK_GRACE"] = "1"
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(root / "examples" / "manual-tunnel" / "start-ninfer.sh"),
+                    "--model",
+                    str(model),
+                    "--api-key-file",
+                    str(key),
+                    "--log-dir",
+                    str(root / "logs"),
+                ],
+                cwd=root,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=60,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("wsl-mirrored-loopback-unavailable", result.stderr)
 
     def test_tunnel_executes_exact_fail_closed_ssh_arguments(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_public_numbers.py
+++ b/tests/test_public_numbers.py
@@ -68,6 +68,19 @@ class PublicNumbersTests(unittest.TestCase):
         ceiling = self.profile["omp_provider"]["context_window"]
         self.assert_in_both(f"{ceiling:,}")
 
+    def test_warm_cold_measurement_matches_receipt(self) -> None:
+        receipt = json.loads(
+            (ROOT / "docs" / "measurements" / "2026-08-29-warm-vs-cold-ttft.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for row in receipt["results"]:
+            self.assertIn(f"{row['session_input_tokens']:,}", self.benchmarks)
+            self.assertIn(f"{row['warm_ttft_s']:.3f} s", self.benchmarks)
+            self.assertIn(f"{row['cold_ttft_s']:.3f} s", self.benchmarks)
+        largest = max(receipt["results"], key=lambda row: row["session_input_tokens"])
+        self.assertIn(f"{largest['warm_ttft_s']:.3f} s", self.readme)
+
     def test_packaged_source_identity_is_authoritative(self) -> None:
         interpretation = self.qualification["evidence_interpretation"]
         self.assertTrue(interpretation["packaged_build_identity_authoritative"])


### PR DESCRIPTION
Closes #15 (hardening half).

- `start-ninfer.sh` now probes host loopback after container start: when the runtime logs `listening on http://127.0.0.1:18089` but the port stays unreachable for a grace window, it exits immediately with `error: wsl-mirrored-loopback-unavailable` and recovery guidance instead of burning the silent 900 s wait. Total deadline behavior is unchanged; the container is still left in place for diagnosis; the authenticated identity validation is untouched and still gates readiness.
- TROUBLESHOOTING: new entries for the loopback-drift signature (recovery: `wsl --shutdown`, restart Docker Desktop) and the non-interactive-SSH Docker credential-helper failure (`DOCKER_CONFIG` workaround).
- Tests: fake-docker harness case proving the named drift error; public-numbers guard binding the published warm-vs-cold TTFT strings to their committed receipt.

Verified: `bash -n` clean; full suite 65/65 OK (drift case exercised, 6.07 s, not skipped); `verify_release.py --require-ready` passes; release evidence byte-identical to `6a78aab`.