### PR TITLE
docs: encode performance-program ordering and fix roadmap restart residue

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,10 @@ intent remains to upstream reusable provider and lifecycle pieces to
 ## Roadmap
 
 `v0.3` made the appliance public: three qualified GPU lanes in one ready manifest, durable
-checkpoint restart on both native Windows lanes, and public install authority with no access gate. Next:
-signing/notarization, a shared public client acceptance runner, concurrency-qualified native
-profiles, and multi-owner clean-install evidence on the path to v1.0. No item becomes a support
+checkpoint restart on both native Windows lanes, and public install authority with no access gate.
+Next, in order: an MTP3 qualification campaign for the RTX 4090 lane, the MTP depth-and-corpus
+ablation, and the durable RTX 5090 container — then signing/notarization, a shared public client
+acceptance runner, and multi-owner clean-install evidence on the path to v1.0. No item becomes a support
 claim before an exact package, receipt, and product manifest bind it.
 
 Scope boundaries and explicit non-claims: [`ROADMAP.md`](ROADMAP.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,9 +100,9 @@ product release. The next product release must publish that exact package or req
 The first public release publishes one exact install lane for each qualified GPU profile:
 
 - qualified RTX 5090 container, RTX 4090 native-Windows, and RTX 3090 native-Windows lanes;
-- durable authenticated process-restart checkpoints on all three GPU lanes; the RTX 5090
-  DirectStorage/io_uring backend must be qualified in the v0.3 campaign before this release claim
-  is final;
+- durable authenticated process-restart checkpoints on both native Windows lanes
+  (DirectStorage-backed, each bound by its restart receipt); the RTX 5090 container keeps
+  live-process warm continuation with OMP transcript replay as its recovery path;
 - the exact RTX 3090 parity package, the published RTX 4090 component rebind, and the new RTX 5090
   runtime through one ready product manifest; and
 - public artifacts and install instructions, with `v0.3.0` as GitHub `Latest` and
@@ -119,7 +119,29 @@ The first public release publishes one exact install lane for each qualified GPU
 
 ## After v0.3.0
 
-The next expensive-to-add-later items are now explicit rather than hidden release debt:
+The performance program has an explicit order; each step is a receipt-gated campaign, not a
+promise:
+
+1. **v0.3.1 — qualify a speculative (MTP3) profile on the RTX 4090 lane.** The cheapest large
+   win: the lane ships MTP0 at 52.330 tok/s while the upstream port measured 229.9 tok/s with
+   MTP7 on its own artifacts. Proven silicon, known campaign shape, no new bytes elsewhere.
+2. **MTP depth-and-corpus ablation.** One unchanged artifact, one context profile, MTP0/3/5/7,
+   measured on an agent-shaped corpus (tool calls, thinking, long turns) rather than a fixed
+   decode fixture — the 99.87% v0.3 acceptance is a fixed-workload artifact, and this ablation
+   decides the draft depth every lane ships next.
+3. **v0.4-class — durable RTX 5090 container.** Promote the existing durable-serve candidate
+   branch into a new runtime image so the container lane gains the process-restart continuation
+   the native lanes already claim; new bytes mean a full 5090 requalification and its own
+   freeze review.
+4. **v0.4-class decision — `nvfp4` artifact evaluation.** The upstream campaign shows 3.48×
+   groupwise-int prefill and a higher GPQA row for `nvfp4`; adopting it swaps the pinned model
+   artifact and therefore forces requalification of all three lanes. Decide with the ablation
+   data in hand; until then the groupwise-int artifact stays pinned.
+
+Parked until >131,072-token contexts matter: paged host-to-device KV prefetch and the
+E8-lattice/RotorQuant ceiling work the family ports carry upstream.
+
+The remaining expensive-to-add-later items stay explicit rather than hidden release debt:
 
 - adopt the shared native-Windows source-first qualification sequence in
   [the release process](docs/RELEASES.md#next-native-release-sequencing);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -246,7 +246,8 @@ Planned measurements that would sharpen the picture; contributions welcome
   above; the fuller sweep — 10K/37K/100K-token sessions with repetitions and client-side vantage —
   remains open.
 - **End-to-end OMP turn latency distribution** on Golden-class agent tasks, client-measured.
-- **Matched MTP0/MTP3 ablation** on one unchanged artifact and context profile.
+- **Matched MTP depth sweep (MTP0/3/5/7)** on one unchanged artifact and context profile,
+  measured on an agent-shaped corpus rather than a fixed decode fixture.
 - **Concurrency curves** for future 3090/4090 profiles only after exact memory-admission gates are
   defined.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -115,6 +115,14 @@ Entry detail:
   product lane would need its own qualification pass (quality table in
   [`BENCHMARKS.md`](BENCHMARKS.md)).
 
+## Current order
+
+The backlog below is a pool; the program's order is fixed and lives in
+[`ROADMAP.md`](../ROADMAP.md#after-v030): the RTX 4090 MTP3 qualification campaign first, then
+the MTP depth-and-corpus ablation that decides draft depth for every lane, then the durable RTX
+5090 container promotion, with the `nvfp4` artifact swap as a v0.4-class requalification decision
+gated on the ablation data.
+
 ## Ideas backlog
 
 Open, unclaimed, or in-flight. Claim one by opening an issue in
@@ -124,11 +132,11 @@ hypothesis and method before writing code.
 | Idea | Why it should work | Status |
 | --- | --- | --- |
 | Fuse Q4/Q5 GEMV/MMA epilogues with adjacent normalization | Removes a full activation round trip per layer at decode shapes | open |
-| Qualify a speculative (MTP) profile on the RTX 4090 lane | The qualified lane runs MTP0 at 52.330 tok/s while the upstream port measured 229.9 tok/s with MTP7; a qualified MTP3 profile should close most of that gap | open |
-| DirectStorage-style weight paging on the 5090 lane | The io_uring checkpoint backend ships in the v0.3.0 container lane and Windows DirectStorage in both native lanes; the remaining work is a fixed end-to-end cold-start product comparison | shipped foundation; comparison open |
+| Qualify a speculative (MTP) profile on the RTX 4090 lane | The qualified lane runs MTP0 at 52.330 tok/s while the upstream port measured 229.9 tok/s with MTP7; a qualified MTP3 profile should close most of that gap | ordered first |
+| Durable RTX 5090 container (serve-layer session persistence) | The engine backends shipped in v0.3.0; promoting the durable-serve candidate branch gives the container lane restart continuation and requires full requalification | ordered third |
 | Paged host-to-device KV prefetch beyond 262K tokens | Extends usable context past resident KV capacity without a quality change | open |
 | Durable session checkpoints → process-restart continuation | Both native Windows lanes bind passing restart gates: 102K restored continuation on RTX 4090 and 310 MB checkpoint restoration on RTX 3090; the RTX 5090 container keeps transcript-replay recovery, and its durable candidate branch is the next step | released on both native lanes; container lane open |
-| MTP acceptance modelling for Qwen3.8 | Recorded acceptance ranges from 48.9% on an upstream `nvfp4` workload through 77.0% in v0.1 to 99.87% on the fixed v0.2 decode workload; a matched corpus is needed before attributing the delta to quantization | open |
+| MTP depth-and-corpus ablation for Qwen3.8 | Recorded acceptance ranges from 48.9% on an upstream `nvfp4` workload through 99.87% on the fixed v0.3 decode workload — a fixed-workload artifact; sweep MTP0/3/5/7 on one unchanged artifact against an agent-shaped corpus (tool calls, thinking, long turns) before attributing deltas or picking shipped draft depth | ordered second |
 | DFlash-style deeper drafting (k=7) on 27B | Upstream measured 764–786 tok/s at 65–66% acceptance on 35B-A3B with DFlash; unknown economics on dense 27B | open |
 
 ## Contributing a result


### PR DESCRIPTION
Encodes the intended sequence publicly — (1) RTX 4090 MTP3 qualification campaign, (2) MTP depth-and-corpus ablation (MTP0/3/5/7, agent-shaped corpus) that decides shipped draft depth, (3) durable RTX 5090 container promotion with full requalification, (4) nvfp4 as a v0.4-class requalification decision — plus parked KV-ceiling items. Also fixes the ROADMAP shipped-list restart bullet that still carried the pre-decision all-lanes contingent claim (R2-class residue outside the review file set).