### PR TITLE
docs: bind support surfaces to the current release

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark-report.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark-report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: OMP NInfer release
       description: Exact product tag; `python3 scripts/verify_release.py --require-ready` must pass on your clone.
-      placeholder: v0.3.0
+      placeholder: v0.3.1
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/clean-install-report.yml
+++ b/.github/ISSUE_TEMPLATE/clean-install-report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: OMP NInfer release
       description: Exact product tag; `python3 scripts/verify_release.py --require-ready` must pass first.
-      placeholder: v0.3.0
+      placeholder: v0.3.1
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/hardware-report.yml
+++ b/.github/ISSUE_TEMPLATE/hardware-report.yml
@@ -12,7 +12,7 @@ body:
     id: release
     attributes:
       label: OMP NInfer release
-      description: Exact product tag, for example v0.3.0.
+      description: Exact product tag, for example v0.3.1.
     validations:
       required: true
   - type: input

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported trust boundary
 
-`v0.3.0` supports one trusted owner controlling each OMP client and qualified RTX runtime
+The current `v0.3.x` release supports one trusted owner controlling each OMP client and qualified RTX runtime
 host. Local administrators and root can inspect processes, files, container/native runtime state, GPU memory, and
 traffic endpoints. Shared shell hosts, hostile local users, untrusted containers, public HTTP
 service, and tenant isolation are outside the release claim.
@@ -47,7 +47,7 @@ not use this topology where local administrators are outside the trust boundary.
 ## Data flow and retention
 
 OMP stores its normal session transcript and a provider acceleration snapshot on the client. NInfer
-retains bounded Responses/cache state. The `v0.3.0` release publishes authenticated durable
+retains bounded Responses/cache state. The current release publishes authenticated durable
 process-restart continuation for the exact native RTX 4090 and RTX 3090 packages. The RTX 5090
 DirectStorage/io_uring durable-checkpoint backend remains in qualification for the v0.3 campaign; it
 does not inherit a native lane's restart semantics. Native checkpoints and optional request JSONL


### PR DESCRIPTION
Follow-up residue from the v0.3.1 cutover: SECURITY.md support-boundary wording moves from a fixed v0.3.0 to the current release, and issue-form placeholders reference v0.3.1.